### PR TITLE
WIP: store tags in a separate table

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -124,6 +124,15 @@ jdbc-journal {
         message = "message"
       }
     }
+    journal-tag {
+      tableName = "journal_tag"
+      schemaName = ""
+      columnNames {
+        tag = "tag"
+        persistenceId = "persistence_id"
+        sequenceNumber = "sequence_number"
+      }
+    }
   }
 
   tagSeparator = ","
@@ -394,11 +403,21 @@ jdbc-read-journal {
       schemaName = ""
       columnNames {
         ordering = "ordering"
+        deleted = "deleted"
         persistenceId = "persistence_id"
         sequenceNumber = "sequence_number"
         created = "created"
         tags = "tags"
         message = "message"
+      }
+    }
+    journal-tag {
+      tableName = "journal_tag"
+      schemaName = ""
+      columnNames {
+        tag = "tag"
+        persistenceId = "persistence_id"
+        sequenceNumber = "sequence_number"
       }
     }
   }

--- a/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
+++ b/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
@@ -45,12 +45,28 @@ class JournalTableColumnNames(config: Config) {
   override def toString: String = s"JournalTableColumnNames($persistenceId,$sequenceNumber,$created,$tags,$message)"
 }
 
+class JournalTagTableColumnNames(config: Config) {
+  private val cfg = config.asConfig("tables.journal.columnNames")
+  val persistenceId: String = cfg.as[String]("persistenceId", "persistence_id")
+  val sequenceNumber: String = cfg.as[String]("sequenceNumber", "sequence_number")
+  val tag: String = cfg.as[String]("tag", "tag")
+  override def toString: String = s"JournalTagTableColumnNames($persistenceId,$sequenceNumber,$tag)"
+}
+
 class JournalTableConfiguration(config: Config) {
   private val cfg = config.asConfig("tables.journal")
   val tableName: String = cfg.as[String]("tableName", "journal")
   val schemaName: Option[String] = cfg.as[String]("schemaName").trim
   val columnNames: JournalTableColumnNames = new JournalTableColumnNames(config)
   override def toString: String = s"JournalTableConfiguration($tableName,$schemaName,$columnNames)"
+}
+
+class JournalTagTableConfiguration(config: Config) {
+  private val cfg = config.asConfig("tables.journal-tag")
+  val tableName: String = cfg.as[String]("tableName", "journal_tag")
+  val schemaName: Option[String] = cfg.as[String]("schemaName").trim
+  val columnNames: JournalTagTableColumnNames = new JournalTagTableColumnNames(config)
+  override def toString: String = s"JournalTagTableConfiguration($tableName,$schemaName,$columnNames)"
 }
 
 class SnapshotTableColumnNames(config: Config) {
@@ -100,6 +116,7 @@ class SnapshotPluginConfig(config: Config) {
 class JournalConfig(config: Config) {
   val slickConfiguration = new SlickConfiguration(config)
   val journalTableConfiguration = new JournalTableConfiguration(config)
+  val journalTagTableConfiguration = new JournalTagTableConfiguration(config)
   val pluginConfig = new JournalPluginConfig(config)
   val daoConfig = new BaseByteArrayJournalDaoConfig(config)
   val useSharedDb: Option[String] = config.asOptionalNonEmptyString(ConfigKeys.useSharedDb)
@@ -127,6 +144,7 @@ case class JournalSequenceRetrievalConfig(batchSize: Int, maxTries: Int, queryDe
 class ReadJournalConfig(config: Config) {
   val slickConfiguration = new SlickConfiguration(config)
   val journalTableConfiguration = new JournalTableConfiguration(config)
+  val journalTagTableConfiguration = new JournalTagTableConfiguration(config)
   val journalSequenceRetrievalConfiguration = JournalSequenceRetrievalConfig(config)
   val pluginConfig = new ReadJournalPluginConfig(config)
   val refreshInterval: FiniteDuration = config.asFiniteDuration("refresh-interval", 1.second)

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
@@ -25,7 +25,7 @@ import scala.collection.immutable._
 import scala.util.Try
 
 class ByteArrayJournalSerializer(serialization: Serialization, separator: String) extends FlowPersistentReprSerializer[JournalRow] {
-  override def serialize(persistentRepr: PersistentRepr, tags: Set[String]): Try[JournalRow] = {
+  override def serialize(persistentRepr: PersistentRepr): Try[JournalRow] = {
     serialization
       .serialize(persistentRepr)
       .map(JournalRow(
@@ -33,12 +33,14 @@ class ByteArrayJournalSerializer(serialization: Serialization, separator: String
         persistentRepr.deleted,
         persistentRepr.persistenceId,
         persistentRepr.sequenceNr,
-        _,
-        encodeTags(tags, separator)))
+        _
+        //,
+//        encodeTags(Set.empty, separator)
+      )) // TODO re-enable serialization of tags for legacy
   }
 
   override def deserialize(journalRow: JournalRow): Try[(PersistentRepr, Set[String], Long)] = {
     serialization.deserialize(journalRow.message, classOf[PersistentRepr])
-      .map((_, decodeTags(journalRow.tags, separator), journalRow.ordering))
+      .map((_, decodeTags(None /* TODO */, separator), journalRow.ordering))
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/package.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/package.scala
@@ -22,6 +22,7 @@ package object dao {
   def encodeTags(tags: Set[String], separator: String): Option[String] =
     if (tags.isEmpty) None else Option(tags.mkString(separator))
 
+  // TODO, this is no longer used, but we do need this when we want to be able to read tags in the old format
   def decodeTags(tags: Option[String], separator: String): Set[String] =
     tags.map(_.split(separator).toSet).getOrElse(Set.empty[String])
 

--- a/src/main/scala/akka/persistence/jdbc/package.scala
+++ b/src/main/scala/akka/persistence/jdbc/package.scala
@@ -17,5 +17,7 @@
 package akka.persistence
 
 package object jdbc {
-  final case class JournalRow(ordering: Long, deleted: Boolean, persistenceId: String, sequenceNumber: Long, message: Array[Byte], tags: Option[String] = None)
+  final case class JournalRow(ordering: Long, deleted: Boolean, persistenceId: String, sequenceNumber: Long, message: Array[Byte])
+  final case class JournalTagRow(tag: String, persistenceId: String, sequenceNumber: Long)
+
 }

--- a/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
@@ -46,7 +46,7 @@ trait BaseByteArrayReadJournalDao extends ReadJournalDao {
     Source.fromPublisher(db.stream(queries.allPersistenceIdsDistinct(max).result))
 
   override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] =
-    Source.fromPublisher(db.stream(queries.eventsByTag(s"%$tag%", offset, maxOffset, max).result))
+    Source.fromPublisher(db.stream(queries.eventsByTag(tag, offset, maxOffset, max).result))
       .via(serializer.deserializeFlow)
 
   override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] =
@@ -68,10 +68,13 @@ trait OracleReadJournalDao extends ReadJournalDao {
   val queries: ReadJournalQueries
   val serializer: FlowPersistentReprSerializer[JournalRow]
 
-  import readJournalConfig.journalTableConfiguration._
-  import columnNames._
+  import readJournalConfig.journalTableConfiguration.{columnNames => journalColumnNames}
+  import readJournalConfig.journalTagTableConfiguration.{columnNames => tagColumnNames}
 
-  val theTableName = schemaName.map(_ + ".").getOrElse("") + s""""$tableName""""
+  private def fullTableName(schemaName: Option[String], tableName: String) = schemaName.map(_ + ".").getOrElse("") + s""""$tableName""""
+
+  val journalTableName =  fullTableName(readJournalConfig.journalTableConfiguration.schemaName, readJournalConfig.journalTableConfiguration.tableName)
+  val journalTagTableName = fullTableName(readJournalConfig.journalTagTableConfiguration.schemaName, readJournalConfig.journalTagTableConfiguration.tableName)
 
   import profile.api._
 
@@ -83,29 +86,30 @@ trait OracleReadJournalDao extends ReadJournalDao {
   abstract override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] = {
     if (isOracleDriver(profile)) {
       Source.fromPublisher(
-        db.stream(sql"""SELECT DISTINCT "#$persistenceId" FROM #$theTableName WHERE rownum <= $max""".as[String]))
+        db.stream(sql"""SELECT DISTINCT "#${journalColumnNames.persistenceId}" FROM #$journalTableName WHERE rownum <= $max""".as[String]))
     } else {
       super.allPersistenceIdsSource(max)
     }
   }
 
-  implicit val getJournalRow = GetResult(r => JournalRow(r.<<, r.<<, r.<<, r.<<, r.nextBytes(), r.<<))
+  implicit val getJournalRow = GetResult(r => JournalRow(r.<<, r.<<, r.<<, r.<<, r.nextBytes()))
 
   abstract override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] = {
     if (isOracleDriver(profile)) {
       val theOffset = Math.max(0, offset)
-      val theTag = s"%$tag%"
-
       Source.fromPublisher {
         db.stream(
           sql"""
-            SELECT "#$ordering", "#$deleted", "#$persistenceId", "#$sequenceNumber", "#$message", "#$tags"
+            SELECT "#${journalColumnNames.ordering}", "#${journalColumnNames.deleted}", "#${journalColumnNames.persistenceId}", "#${journalColumnNames.sequenceNumber}", "#${journalColumnNames.message}"
             FROM (
-              SELECT * FROM #$theTableName
-              WHERE "#$tags" LIKE $theTag
-              AND "#$ordering" > $theOffset
-              AND "#$ordering" <= $maxOffset
-              ORDER BY "#$ordering"
+              SELECT j."#${journalColumnNames.ordering}", j."#${journalColumnNames.deleted}", j."#${journalColumnNames.persistenceId}", j."#${journalColumnNames.sequenceNumber}", j."#${journalColumnNames.message}"
+              FROM #$journalTableName j, #$journalTagTableName jt
+              WHERE jt."#${tagColumnNames.tag}" = $tag
+              AND j."#${journalColumnNames.persistenceId}" = jt."#${tagColumnNames.persistenceId}"
+              AND j."#${journalColumnNames.sequenceNumber}" = jt."#${tagColumnNames.sequenceNumber}"
+              AND j."#${journalColumnNames.ordering}" > $theOffset
+              AND j."#${journalColumnNames.ordering}" <= $maxOffset
+              ORDER BY j."#${journalColumnNames.ordering}"
             )
             WHERE rownum <= $max""".as[JournalRow])
       }.via(serializer.deserializeFlow)
@@ -141,6 +145,6 @@ trait H2ReadJournalDao extends ReadJournalDao {
 }
 
 class ByteArrayReadJournalDao(val db: Database, val profile: JdbcProfile, val readJournalConfig: ReadJournalConfig, serialization: Serialization)(implicit ec: ExecutionContext, mat: Materializer) extends BaseByteArrayReadJournalDao with OracleReadJournalDao with H2ReadJournalDao {
-  val queries = new ReadJournalQueries(profile, readJournalConfig.journalTableConfiguration)
+  val queries = new ReadJournalQueries(profile, readJournalConfig.journalTableConfiguration, readJournalConfig.journalTagTableConfiguration)
   val serializer = new ByteArrayJournalSerializer(serialization, readJournalConfig.pluginConfig.tagSeparator)
 }

--- a/src/test/resources/oracle-application.conf
+++ b/src/test/resources/oracle-application.conf
@@ -36,6 +36,9 @@ jdbc-journal {
       tableName = "journal"
       schemaName = "SYSTEM"
     }
+    journal-tag {
+      schemaName = "SYSTEM"
+    }
   }
 
   slick = ${slick}
@@ -58,6 +61,9 @@ jdbc-read-journal {
   tables {
     journal {
       tableName = "journal"
+      schemaName = "SYSTEM"
+    }
+    journal-tag {
       schemaName = "SYSTEM"
     }
   }

--- a/src/test/resources/schema/h2/h2-schema.sql
+++ b/src/test/resources/schema/h2/h2-schema.sql
@@ -21,3 +21,13 @@ CREATE TABLE IF NOT EXISTS PUBLIC."snapshot" (
   "snapshot" BYTEA NOT NULL,
   PRIMARY KEY("persistence_id", "sequence_number")
 );
+
+DROP TABLE IF EXISTS PUBLIC."journal_tag";
+
+create table if not exists PUBLIC."journal_tag" (
+  "tag" VARCHAR(255) NOT NULL,
+  "persistence_id" VARCHAR(255) NOT NULL,
+  "sequence_number" BIGINT NOT NULL,
+  constraint "journal_tag_pkey" primary key("tag","persistence_id", "sequence_number"),
+  constraint "journal_tag_pid_sequence_fk" foreign key("persistence_id", "sequence_number") references "journal"("persistence_id", "sequence_number") on delete CASCADE
+);

--- a/src/test/resources/schema/mysql/mysql-schema.sql
+++ b/src/test/resources/schema/mysql/mysql-schema.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS journal_tag;
 DROP TABLE IF EXISTS journal;
 
 CREATE TABLE IF NOT EXISTS journal (
@@ -20,4 +21,12 @@ CREATE TABLE IF NOT EXISTS snapshot (
   created BIGINT NOT NULL,
   snapshot BLOB NOT NULL,
   PRIMARY KEY (persistence_id, sequence_number)
+);
+
+create table journal_tag (
+  tag             VARCHAR(255) NOT NULL,
+  persistence_id  VARCHAR(255) NOT NULL,
+  sequence_number BIGINT       NOT NULL,
+  primary key (tag, persistence_id, sequence_number),
+  constraint journal_tag_persistence_id_fk foreign key (persistence_id, sequence_number) references journal (persistence_id, sequence_number) on delete CASCADE
 );

--- a/src/test/resources/schema/oracle/oracle-schema.sql
+++ b/src/test/resources/schema/oracle/oracle-schema.sql
@@ -42,3 +42,12 @@ CREATE TABLE "snapshot" (
   PRIMARY KEY ("persistence_id", "sequence_number")
 )
 /
+
+CREATE TABLE "journal_tag" (
+  "tag" VARCHAR(255) NOT NULL,
+  "persistence_id" VARCHAR(255) NOT NULL,
+  "sequence_number" NUMERIC NOT NULL,
+  PRIMARY KEY("tag", "persistence_id", "sequence_number"),
+  CONSTRAINT "journal_tag_persistence_id_fk" FOREIGN KEY ("persistence_id", "sequence_number") REFERENCES "journal" ("persistence_id", "sequence_number") ON DELETE CASCADE
+)
+/

--- a/src/test/resources/schema/postgres/postgres-schema.sql
+++ b/src/test/resources/schema/postgres/postgres-schema.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS public.journal_tag;
 DROP TABLE IF EXISTS public.journal;
 
 CREATE TABLE IF NOT EXISTS public.journal (
@@ -22,3 +23,11 @@ CREATE TABLE IF NOT EXISTS public.snapshot (
   PRIMARY KEY(persistence_id, sequence_number)
 );
 
+
+create table if not exists public.journal_tag (
+  tag VARCHAR(255) NOT NULL,
+  persistence_id VARCHAR(255) NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  constraint journal_tag_pkey primary key(tag,persistence_id,sequence_number),
+  constraint journal_tag_pid_sequence_fk foreign key(persistence_id,sequence_number) references journal(persistence_id,sequence_number) on delete CASCADE
+);

--- a/src/test/scala/akka/persistence/jdbc/journal/dao/JournalTablesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/dao/JournalTablesTest.scala
@@ -24,12 +24,17 @@ class JournalTablesTest extends TablesTestSpec {
   val journalTableConfiguration = journalConfig.journalTableConfiguration
 
   object TestByteAJournalTables extends JournalTables {
-    override val profile: JdbcProfile = slick.jdbc.PostgresProfile
+    override val profile: JdbcProfile = slick.jdbc.OracleProfile
     override val journalTableCfg = journalTableConfiguration
+    override val journalTagTableCfg = journalConfig.journalTagTableConfiguration
   }
 
   "JournalTable" should "be configured with a schema name" in {
     TestByteAJournalTables.JournalTable.baseTableRow.schemaName shouldBe journalTableConfiguration.schemaName
+
+    import TestByteAJournalTables.profile.api._
+
+    TestByteAJournalTables.JournalTagTable.schema.createStatements.foreach(println)
   }
 
   it should "be configured with a table name" in {

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -201,7 +201,7 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
       journalOps.withCurrentEventsByTag()(tag, NoOffset) { tp =>
         // The stream must complete within the given amount of time
         // This make take a while in case the journal sequence actor detects gaps
-        val allEvents = tp.toStrict(atMost = 20.seconds)
+        val allEvents = tp.toStrict(atMost = 40.seconds) // TODO I needed to increase this, performance regression?
         allEvents.size should be >= 600
         val expectedOffsets = 1L.to(allEvents.size).map(Sequence.apply)
         allEvents.map(_.offset) shouldBe expectedOffsets

--- a/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
@@ -23,6 +23,7 @@ abstract class JournalSequenceActorTest(configFile: String, isOracle: Boolean) e
 
   val journalSequenceActorConfig = readJournalConfig.journalSequenceRetrievalConfiguration
   val journalTableCfg = journalConfig.journalTableConfiguration
+  val journalTagTableCfg = journalConfig.journalTagTableConfiguration
 
   import profile.api._
 

--- a/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -211,6 +211,7 @@ trait PostgresCleaner extends QueryTestSpec {
 
   val actionsClearPostgres =
     DBIO.seq(
+      sqlu"""TRUNCATE journal_tag""",
       sqlu"""TRUNCATE journal""",
       sqlu"""TRUNCATE snapshot""").transactionally
 
@@ -233,8 +234,13 @@ trait MysqlCleaner extends QueryTestSpec {
 
   val actionsClearMySQL =
     DBIO.seq(
+      // To allow truncating journal_tag, we temporarily need to disable the foreign key checks
+      sqlu"""SET FOREIGN_KEY_CHECKS = 0""",
+      sqlu"""TRUNCATE journal_tag""",
       sqlu"""TRUNCATE journal""",
-      sqlu"""TRUNCATE snapshot""").transactionally
+      sqlu"""TRUNCATE snapshot""",
+      sqlu"""SET FOREIGN_KEY_CHECKS = 1"""
+  ).transactionally
 
   def clearMySQL(): Unit =
     withDatabase(_.run(actionsClearMySQL).futureValue)
@@ -278,6 +284,7 @@ trait H2Cleaner extends QueryTestSpec {
 
   val actionsClearH2 =
     DBIO.seq(
+      sqlu"""TRUNCATE TABLE journal_tag""",
       sqlu"""TRUNCATE TABLE journal""",
       sqlu"""TRUNCATE TABLE snapshot""").transactionally
 

--- a/src/test/scala/akka/persistence/jdbc/query/dao/ReadJournalTablesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/dao/ReadJournalTablesTest.scala
@@ -27,6 +27,7 @@ class ReadJournalTablesTest extends TablesTestSpec {
   object TestByteAReadJournalTables extends JournalTables {
     override val profile: JdbcProfile = slick.jdbc.PostgresProfile
     override val journalTableCfg = readJournalTableConfiguration
+    override val journalTagTableCfg = readJournalConfig.journalTagTableConfiguration
   }
 
   "JournalTable" should "be configured with a schema name" in {

--- a/src/test/scala/akka/persistence/jdbc/util/DropCreate.scala
+++ b/src/test/scala/akka/persistence/jdbc/util/DropCreate.scala
@@ -36,6 +36,7 @@ trait DropCreate extends ClasspathResources {
 
   val listOfOracleDropQueries = List(
     """ALTER SESSION SET ddl_lock_timeout = 15""", // (ddl lock timeout in seconds) this allows tests which are still writing to the db to finish gracefully
+    """DROP TABLE "journal_tag" CASCADE CONSTRAINT""",
     """DROP TABLE "journal" CASCADE CONSTRAINT""",
     """DROP TABLE "snapshot" CASCADE CONSTRAINT""",
     """DROP TABLE "deleted_to" CASCADE CONSTRAINT""",


### PR DESCRIPTION
As an experiment. I wanted to make the changes needed to store tags in a separate table. Here is my work so far.

- Since this first version is just to find out if this works, I decided to not yet make this backwards compatible. In case we do choose to continue with this, we should definitely ensure backwards (and forwards) compatibility. Also we need a simple way to migrate.
- There is one H2 test that seems to fail with timeouts, I have not yet figured out why this fails for H2 bt not for other databases
- I did not yet execute performance tests. 
  - We now insert in two tables, so inserting will be slightly slower (we should test how much)
  - The eventsByTag query needs to search in two tables, and the filtering conditions (tag and ordering) are in two different tables. So I guess the query strategy will still not be optimal (but hopefully better than before).

If we complete this work then this PR will solve #168 and it will make #172 obsolete
