### PR TITLE
[WIP] Enable release publishing from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,17 @@ before_script:
   - psql -c 'create database docker;' -U postgres
 addons:
   postgresql: "9.4"
+
 script: "./build.sh"
+
+jobs:
+  include:
+    - stage: publish
+      script: "./sbt-publish.sh"
+
+stages:
+  - name: publish
+    if: repo = dnvriend/akka-persistence-jdbc AND type != pull_request AND tag =~ ^v
 
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,3 +28,5 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "4.1.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
+
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")


### PR DESCRIPTION
This PR make it possible to release by creating a tag on GitHub's interface. Once the tag is in place, Travis will build and publish to Bintray.

TODO: 
@WellingR or @dnvriend, there is one extra bit to do to get it working.
One of you need to add two Bintray environment variables to Travis. We need `BINTRAY_PASS` and `BINTRAY_USER` configured in Travis as env variables for the build. 
Once that in place, the Bintray plugin will be able to read it and publish to Bintray. 

The whole process works as follow:

* a maintainer creates a tag using GitHub's release page
* travis 'sees' it and starts a build for publishing
* dynver plugin reads the tag and set current version to the tag, for instance, if tag is v3.5.1, dynver will set project version to `3.5.1`.
* Bintray plugin reads credentials from env var and publish to Bintray
* we still need the manual sync from Bintray to Maven (done by Dennis)