### PR TITLE
Switch to Lightbend organisation and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/dnvriend/akka-persistence-jdbc](https://badges.gitter.im/dnvriend/akka-persistence-jdbc.svg)](https://gitter.im/dnvriend/akka-persistence-jdbc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Join the contributors chat at https://gitter.im/akka-persistence-jdbc/contributors](https://img.shields.io/badge/chat-contributors%20channel-green.svg)](https://gitter.im/akka-persistence-jdbc/contributors?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/dnvriend/akka-persistence-jdbc.svg?branch=master)](https://travis-ci.org/dnvriend/akka-persistence-jdbc)
+[![Build Status](https://travis-ci.org/akka/akka-persistence-jdbc.svg?branch=master)](https://travis-ci.org/akka/akka-persistence-jdbc)
 [![Download](https://api.bintray.com/packages/dnvriend/maven/akka-persistence-jdbc/images/download.svg)](https://bintray.com/dnvriend/maven/akka-persistence-jdbc/_latestVersion)
 [![Latest version](https://index.scala-lang.org/dnvriend/akka-persistence-jdbc/akka-persistence-jdbc/latest.svg)](https://index.scala-lang.org/dnvriend/akka-persistence-jdbc/akka-persistence-jdbc)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a5d8576c2a56479ab1c40d87c78bba58)](https://www.codacy.com/app/dnvriend/akka-persistence-jdbc?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=dnvriend/akka-persistence-jdbc&amp;utm_campaign=Badge_Grade)
@@ -19,9 +19,9 @@ libraryDependencies += "com.github.dnvriend" %% "akka-persistence-jdbc" % "3.5.2
 
 ## Release notes
 
-The release notes can be found [here](https://github.com/dnvriend/akka-persistence-jdbc/releases).
+The release notes can be found [here](https://github.com/akka/akka-persistence-jdbc/releases).
 
-For change log prior to v3.2.0, visit [Version History Page (wiki)](https://github.com/dnvriend/akka-persistence-jdbc/wiki/Version-History).
+For change log prior to v3.2.0, visit [Version History Page (wiki)](https://github.com/akka/akka-persistence-jdbc/wiki/Version-History).
 
 ## Contribution policy
 
@@ -52,15 +52,15 @@ Configure `slick`:
 
 ## Database Schema
 
-- [Postgres Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/postgres/postgres-schema.sql)
-- [MySQL Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/mysql/mysql-schema.sql)
-- [H2 Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/h2/h2-schema.sql)
-- [Oracle Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/oracle/oracle-schema.sql)
-- [SQL Server Schema](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/schema/sqlserver/sqlserver-schema.sql)
+- [Postgres Schema](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/schema/postgres/postgres-schema.sql)
+- [MySQL Schema](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/schema/mysql/mysql-schema.sql)
+- [H2 Schema](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/schema/h2/h2-schema.sql)
+- [Oracle Schema](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/schema/oracle/oracle-schema.sql)
+- [SQL Server Schema](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/schema/sqlserver/sqlserver-schema.sql)
 
 ## Configuration
 
-akka-persistence-jdbc provides the defaults as part of the [reference.conf](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/main/resources/reference.conf)
+akka-persistence-jdbc provides the defaults as part of the [reference.conf](https://github.com/akka/akka-persistence-jdbc/blob/master/src/main/resources/reference.conf)
 this file documents all the values which can be configured.
 
 There are several possible ways to configure loading your database connections. Options will be explained below.
@@ -71,26 +71,26 @@ There is the possibility to create a separate database connection pool per journ
 one pool for the snapshot-journal, and one pool for the read-journal). This is the default and the following example
 configuration shows how this is configured:
 
-- [Postgres](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/postgres-application.conf)
-- [MySQL](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/mysql-application.conf)
-- [H2](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/h2-application.conf)
-- [Oracle](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/oracle-application.conf)
-- [SQL Server](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/sqlserver-application.conf)
+- [Postgres](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/postgres-application.conf)
+- [MySQL](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/mysql-application.conf)
+- [H2](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/h2-application.conf)
+- [Oracle](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/oracle-application.conf)
+- [SQL Server](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/sqlserver-application.conf)
 
 ### Sharing the database connection pool between the journals
 
 In order to create only one connection pool which is shared between all journals the following configuration can be used:
 
-- [Postgres](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/postgres-shared-db-application.conf)
-- [MySQL](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/mysql-shared-db-application.conf)
-- [H2](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/h2-shared-db-application.conf)
-- [Oracle](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/oracle-shared-db-application.conf)
-- [SQL Server](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/test/resources/sqlserver-shared-db-application.conf)
+- [Postgres](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/postgres-shared-db-application.conf)
+- [MySQL](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/mysql-shared-db-application.conf)
+- [H2](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/h2-shared-db-application.conf)
+- [Oracle](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/oracle-shared-db-application.conf)
+- [SQL Server](https://github.com/akka/akka-persistence-jdbc/blob/master/src/test/resources/sqlserver-shared-db-application.conf)
 
 ### Customized loading of the db connection
 
 It is also possible to load a custom database connection. 
-In order to do so a custom implementation of [SlickDatabaseProvider](https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/main/scala/akka/persistence/jdbc/util/SlickExtension.scala)
+In order to do so a custom implementation of [SlickDatabaseProvider](https://github.com/akka/akka-persistence-jdbc/blob/master/src/main/scala/akka/persistence/jdbc/util/SlickExtension.scala)
 needs to be created. The methods that need to be implemented supply the Slick `Database` and `Profile` to the journals.
 
 To enable your custom `SlickDatabaseProvider`, the fully qualified class name of the `SlickDatabaseProvider`
@@ -331,9 +331,9 @@ The plugin automatically shuts down the HikariCP connection pool when the ActorS
 This is done using [ActorSystem.registerOnTermination](https://doc.akka.io/api/akka/current/akka/actor/ActorSystem.html#registerOnTermination[T](code:=>T):Unit).
 
 [slick]: http://slick.lightbend.com/
-[slick-jndi]: http://slick.typesafe.com/doc/3.3.0/database.html#using-a-jndi-name
-[apache]: http://www.apache.org/licenses/LICENSE-2.0
-[w3c-cond]: http://www.w3.org/Consortium/cepc/
-[w3c-proc]: http://www.w3.org/Consortium/pwe/#Procedures
-[ds]: http://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
-[event-adapter]: http://doc.akka.io/docs/akka/current/scala/persistence.html#event-adapters-scala
+[slick-jndi]: http://slick.typesafe.com/doc/3.3.1/database.html#using-a-jndi-name
+[apache]: https://www.apache.org/licenses/LICENSE-2.0
+[w3c-cond]: https://www.w3.org/Consortium/cepc/
+[w3c-proc]: https://www.w3.org/Consortium/pwe/#Procedures
+[ds]: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
+[event-adapter]: https://doc.akka.io/docs/akka/current/persistence.html#event-adapters-scala

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -4,11 +4,9 @@ import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import com.typesafe.tools.mima.core.IncompatibleResultTypeProblem
 import com.typesafe.tools.mima.core.ProblemFilters
 import com.typesafe.tools.mima.plugin.MimaKeys.{mimaBinaryIssueFilters, mimaPreviousArtifacts}
-import de.heikoseeberger.sbtheader.License.ALv2
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.headerLicense
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{HeaderLicense, headerLicense}
 import sbt.Keys._
 import sbt._
-
 import SbtScalariform.autoImport._
 import scalariform.formatter.preferences.FormattingPreferences
 
@@ -35,12 +33,18 @@ object ProjectAutoPlugin extends AutoPlugin {
 
   override val projectSettings: Seq[Setting[_]] = SbtScalariform.projectSettings ++ mimaDefaultSettings ++ Seq(
     name := "akka-persistence-jdbc",
-    organization := "com.github.dnvriend",
-    organizationName := "Dennis Vriend",
+    organization := "com.lightbend.akka",
+    organizationName := "Lightbend Inc.",
+    organizationHomepage := Some(url("https://www.lightbend.com/")),
+    homepage := Some(url("https://github.com/akka/akka-persistence-jdbc")),
+    scmInfo := Some(ScmInfo(url("https://github.com/akka/akka-persistence-jdbc"), "git@github.com:akka/akka-persistence-jdbc.git")),
+    developers += Developer("contributors",
+      "Contributors",
+      "https://gitter.im/akka/dev",
+      url("https://github.com/akka/akka-persistence-jdbc/graphs/contributors")),
+    licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
     description := "A plugin for storing events in an event journal akka-persistence-jdbc",
     startYear := Some(2014),
-
-    licenses += ("Apache-2.0", url("http://opensource.org/licenses/apache2.0.php")),
 
     scalaVersion := ScalaVersion,
 
@@ -75,7 +79,13 @@ object ProjectAutoPlugin extends AutoPlugin {
     // show full stack traces and test case durations
     testOptions in Test += Tests.Argument("-oDF"),
 
-    headerLicense := Some(ALv2("2018", "Dennis Vriend")),
+    headerLicense := Some(
+      HeaderLicense.Custom(
+        """|Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+           |Copyright (C) 2019 - 2019 Lightbend Inc. <https://www.lightbend.com>
+           |""".stripMargin
+      )
+    ),
 
     resolvers += Resolver.typesafeRepo("releases"),
     resolvers += Resolver.jcenterRepo,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
 // enable updating file headers eg. for copyright
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "4.1.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")
 
 // enable release process
 // https://github.com/sbt/sbt-release

--- a/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -156,7 +156,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
             val nextFrom: Long = lastSeqNrInBatch match {
               // Continue querying from the last sequence number (the events are ordered)
               case Some(lastSeqNr) => lastSeqNr + 1
-              case None => from
+              case None            => from
             }
             Some((nextFrom, nextControl), xs)
           }
@@ -169,9 +169,9 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
             akka.pattern.after(readJournalConfig.refreshInterval, system.scheduler)(retrieveNextBatch())
         }
     }
-    .mapConcat(identity)
-    .mapConcat(adaptEvents)
-    .map(repr => EventEnvelope(Sequence(repr.sequenceNr), repr.persistenceId, repr.sequenceNr, repr.payload))
+      .mapConcat(identity)
+      .mapConcat(adaptEvents)
+      .map(repr => EventEnvelope(Sequence(repr.sequenceNr), repr.persistenceId, repr.sequenceNr, repr.payload))
   }
 
   /**

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -17,8 +17,8 @@
 package akka.persistence.jdbc.query
 
 import akka.Done
-import akka.persistence.jdbc.query.EventAdapterTest.{Event, TaggedAsyncEvent}
-import akka.persistence.query.{EventEnvelope, Sequence}
+import akka.persistence.jdbc.query.EventAdapterTest.{ Event, TaggedAsyncEvent }
+import akka.persistence.query.{ EventEnvelope, Sequence }
 
 import scala.concurrent.Future
 import scala.concurrent.duration._


### PR DESCRIPTION
## Purpose

Adapt to the home:
- update links in readme
- include Lightbend in the license
- change the organisation name to "com.lightbend.akka"
