### PR TITLE
Build for Scala 2.12 and 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - docker inspect sqlserver
   - docker ps -a
 scala:
-  - 2.11.12
   - 2.12.8
   - 2.13.0
 jdk:


### PR DESCRIPTION
Akka Persistence JDBC 4.0 will not support Scala 2.11 anymore.