### PR TITLE
Use scalafmt instead of scalariform

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,52 @@
+version = 2.2.2
+
+style = defaultWithAlign
+
+docstrings                 = JavaDoc
+indentOperator             = spray
+maxColumn                  = 120
+rewrite.rules              = [RedundantParens, SortImports, AvoidInfix]
+unindentTopLevelOperators  = true
+align.tokens               = [{code = "=>", owner = "Case"}]
+align.openParenDefnSite    = false
+align.openParenCallSite    = false
+optIn.breakChainOnFirstMethodDot = false
+optIn.configStyleArguments = false
+danglingParentheses = false
+spaces.inImportCurlyBraces = true
+rewrite.neverInfix.excludeFilters = [
+  and
+  min
+  max
+  until
+  to
+  by
+  eq
+  ne
+  "should.*"
+  "contain.*"
+  "must.*"
+  in
+  ignore
+  be
+  taggedAs
+  thrownBy
+  synchronized
+  have
+  when
+  size
+  only
+  noneOf
+  oneElementOf
+  noElementsOf
+  atLeastOneElementOf
+  atMostOneElementOf
+  allElementsOf
+  inOrderElementsOf
+  theSameElementsAs
+]
+rewriteTokens = {
+  "⇒": "=>"
+  "→": "->"
+  "←": "<-"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ jobs:
     - stage: check
       env: CMD="+Test/compile"
       name: "Compile all code with Scala 2.12 and 2.13"
+    - env: CMD="scalafmtCheckAll scalafmtSbtCheck"
+      name: "Check that code has been formatted"
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ script:
 jobs:
   include:
     - stage: check
-      env: CMD="+Test/compile"
+      env: CMD=";scalafmtCheckAll;scalafmtSbtCheck"
+      name: "Code style check (fixed with `sbt scalafmtAll;scalafmtSbt`)"
+    - env: CMD="+Test/compile"
       name: "Compile all code with Scala 2.12 and 2.13"
-    - env: CMD=";scalafmtCheckAll;scalafmtSbtCheck"
-      name: "Check that code has been formatted"
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     - stage: check
       env: CMD="+Test/compile"
       name: "Compile all code with Scala 2.12 and 2.13"
-    - env: CMD="scalafmtCheckAll scalafmtSbtCheck"
+    - env: CMD=";scalafmtCheckAll;scalafmtSbtCheck"
       name: "Check that code has been formatted"
 
     - stage: test

--- a/bintray.sbt
+++ b/bintray.sbt
@@ -39,6 +39,4 @@ bintrayPackageAttributes ~=
   (_ ++ Map(
     "website_url" -> Seq(bintry.Attr.String("https://github.com/dnvriend/demo-akka-persistence-jdbc")),
     "github_repo" -> Seq(bintry.Attr.String("https://github.com/dnvriend/akka-persistence-jdbc.git")),
-    "issue_tracker_url" -> Seq(bintry.Attr.String("https://github.com/dnvriend/akka-persistence-jdbc/issues/"))
-    )
-  )
+    "issue_tracker_url" -> Seq(bintry.Attr.String("https://github.com/dnvriend/akka-persistence-jdbc/issues/"))))

--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,22 @@
-import com.typesafe.tools.mima.core.{IncompatibleResultTypeProblem, ProblemFilters}
+import com.typesafe.tools.mima.core.{ IncompatibleResultTypeProblem, ProblemFilters }
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaBinaryIssueFilters
 
-lazy val `akka-persistence-jdbc` = project.in(file("."))
+lazy val `akka-persistence-jdbc` = project
+  .in(file("."))
   .settings(
     name := "akka-persistence-jdbc",
     libraryDependencies ++= Dependencies.Libraries,
     mimaBinaryIssueFilters ++= Seq(
-      // Scala 2.11 issue which occurs because the signature of an internal lambda has changed. This lambda is not accessible outside of the method itself
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.persistence.jdbc.util.DefaultSlickDatabaseProvider#lambda#1.apply")
-    ),
+        // Scala 2.11 issue which occurs because the signature of an internal lambda has changed. This lambda is not accessible outside of the method itself
+        ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "akka.persistence.jdbc.util.DefaultSlickDatabaseProvider#lambda#1.apply")),
     // special handling as we change organization id
-    mimaPreviousArtifacts := ProjectAutoPlugin.determineMimaPreviousArtifacts(scalaBinaryVersion.value)
-  )
+    mimaPreviousArtifacts := ProjectAutoPlugin.determineMimaPreviousArtifacts(scalaBinaryVersion.value))
 
 Global / onLoad := (Global / onLoad).value.andThen { s =>
   val v = version.value
   if (dynverGitDescribeOutput.value.hasNoTags)
     throw new MessageOnlyException(
-      s"Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Derived version: $v"
-    )
+      s"Failed to derive version from git tags. Maybe run `git fetch --unshallow`? Derived version: $v")
   s
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,6 @@ import sbt._
 import Keys._
 
 object Dependencies {
-
   val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
 
   val Scala212 = "2.12.8"
@@ -31,7 +30,5 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-persistence-tck" % AkkaVersion % Test,
     "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
     "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
-    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
-  )
-
+    "org.scalatest" %% "scalatest" % ScalaTestVersion % Test)
 }

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -1,79 +1,73 @@
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import de.heikoseeberger.sbtheader.HeaderPlugin
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{HeaderLicense, headerLicense}
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{ headerLicense, HeaderLicense }
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
 
 object ProjectAutoPlugin extends AutoPlugin {
-
-  object autoImport {
-  }
+  object autoImport {}
 
   override val requires = JvmPlugin && HeaderPlugin
 
-  override def globalSettings = Seq(
-    organization := "com.lightbend.akka",
-    organizationName := "Lightbend Inc.",
-    organizationHomepage := Some(url("https://www.lightbend.com/")),
-    homepage := Some(url("https://github.com/akka/akka-persistence-jdbc")),
-    scmInfo := Some(ScmInfo(url("https://github.com/akka/akka-persistence-jdbc"), "git@github.com:akka/akka-persistence-jdbc.git")),
-    developers += Developer("contributors",
-      "Contributors",
-      "https://gitter.im/akka/dev",
-      url("https://github.com/akka/akka-persistence-jdbc/graphs/contributors")),
-    licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
-    description := "A plugin for storing events in an event journal akka-persistence-jdbc",
-    startYear := Some(2014)
-  )
+  override def globalSettings =
+    Seq(
+      organization := "com.lightbend.akka",
+      organizationName := "Lightbend Inc.",
+      organizationHomepage := Some(url("https://www.lightbend.com/")),
+      homepage := Some(url("https://github.com/akka/akka-persistence-jdbc")),
+      scmInfo := Some(
+          ScmInfo(
+            url("https://github.com/akka/akka-persistence-jdbc"),
+            "git@github.com:akka/akka-persistence-jdbc.git")),
+      developers += Developer(
+          "contributors",
+          "Contributors",
+          "https://gitter.im/akka/dev",
+          url("https://github.com/akka/akka-persistence-jdbc/graphs/contributors")),
+      licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
+      description := "A plugin for storing events in an event journal akka-persistence-jdbc",
+      startYear := Some(2014))
 
   override val trigger: PluginTrigger = allRequirements
 
   override val projectSettings: Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
-    crossVersion := CrossVersion.binary,
-    crossScalaVersions := Dependencies.ScalaVersions,
-    scalaVersion := Dependencies.Scala212,
-    Test / fork := true,
-    Test / parallelExecution := false,
-    Test / logBuffered := true,
-
-    scalacOptions ++= Seq(
-      "-encoding",
-      "UTF-8",
-      "-deprecation",
-      "-feature",
-      "-unchecked",
-      "-Xlog-reflective-calls",
-      "-language:higherKinds",
-      "-language:implicitConversions",
-      "-target:jvm-1.8"
-    ),
-
-    scalacOptions += {
-      if (scalaVersion.value.startsWith("2.13")) ""
-      else "-Ypartial-unification"
-    },
-    scalacOptions += "-Ydelambdafy:method",
-
-    // show full stack traces and test case durations
-    Test / testOptions += Tests.Argument("-oDF"),
-
-    headerLicense := Some(
-      HeaderLicense.Custom(
-        """|Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+      crossVersion := CrossVersion.binary,
+      crossScalaVersions := Dependencies.ScalaVersions,
+      scalaVersion := Dependencies.Scala212,
+      Test / fork := true,
+      Test / parallelExecution := false,
+      Test / logBuffered := true,
+      scalacOptions ++= Seq(
+          "-encoding",
+          "UTF-8",
+          "-deprecation",
+          "-feature",
+          "-unchecked",
+          "-Xlog-reflective-calls",
+          "-language:higherKinds",
+          "-language:implicitConversions",
+          "-target:jvm-1.8"),
+      scalacOptions += {
+        if (scalaVersion.value.startsWith("2.13")) ""
+        else "-Ypartial-unification"
+      },
+      scalacOptions += "-Ydelambdafy:method",
+      // show full stack traces and test case durations
+      Test / testOptions += Tests.Argument("-oDF"),
+      headerLicense := Some(
+          HeaderLicense.Custom("""|Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
            |Copyright (C) 2019 - 2019 Lightbend Inc. <https://www.lightbend.com>
-           |""".stripMargin
-      )
-    ),
-
-    resolvers += Resolver.typesafeRepo("releases"),
-    resolvers += Resolver.jcenterRepo,
- )
+           |""".stripMargin)),
+      resolvers += Resolver.typesafeRepo("releases"),
+      resolvers += Resolver.jcenterRepo)
 
   def determineMimaPreviousArtifacts(scalaBinVersion: String): Set[ModuleID] = {
-    val compatVersions: Set[String] = if (scalaBinVersion.startsWith("2.13")) Set("3.5.2") else {
-      Set("3.5.0", "3.5.1", "3.5.2")
-    }
+    val compatVersions: Set[String] =
+      if (scalaBinVersion.startsWith("2.13")) Set("3.5.2")
+      else {
+        Set("3.5.0", "3.5.1", "3.5.2")
+      }
     compatVersions.map { v =>
       "com.github.dnvriend" % ("akka-persistence-jdbc_" + scalaBinVersion) % v
     }

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -1,28 +1,16 @@
-import com.typesafe.sbt.SbtScalariform
-import com.typesafe.sbt.SbtScalariform.ScalariformKeys
-import com.typesafe.sbt.SbtScalariform.autoImport._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{HeaderLicense, headerLicense}
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
-import scalariform.formatter.preferences.FormattingPreferences
 
 object ProjectAutoPlugin extends AutoPlugin {
 
   object autoImport {
   }
 
-  final val formattingPreferences: FormattingPreferences = {
-    import scalariform.formatter.preferences._
-    FormattingPreferences()
-      .setPreference(AlignSingleLineCaseStatements, true)
-      .setPreference(AlignSingleLineCaseStatements.MaxArrowIndent, 100)
-      .setPreference(DoubleIndentConstructorArguments, true)
-  }
-
-  override val requires = com.typesafe.sbt.SbtScalariform && JvmPlugin && HeaderPlugin
+  override val requires = JvmPlugin && HeaderPlugin
 
   override def globalSettings = Seq(
     organization := "com.lightbend.akka",
@@ -41,14 +29,13 @@ object ProjectAutoPlugin extends AutoPlugin {
 
   override val trigger: PluginTrigger = allRequirements
 
-  override val projectSettings: Seq[Setting[_]] = SbtScalariform.projectSettings ++ mimaDefaultSettings ++ Seq(
+  override val projectSettings: Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
     crossVersion := CrossVersion.binary,
     crossScalaVersions := Dependencies.ScalaVersions,
     scalaVersion := Dependencies.Scala212,
     Test / fork := true,
     Test / parallelExecution := false,
     Test / logBuffered := true,
-    scalariformAutoformat := true,
 
     scalacOptions ++= Seq(
       "-encoding",
@@ -81,9 +68,6 @@ object ProjectAutoPlugin extends AutoPlugin {
 
     resolvers += Resolver.typesafeRepo("releases"),
     resolvers += Resolver.jcenterRepo,
-
-    ScalariformKeys.preferences in Compile := formattingPreferences,
-    ScalariformKeys.preferences in Test := formattingPreferences,
  )
 
   def determineMimaPreviousArtifacts(scalaBinVersion: String): Set[ModuleID] = {

--- a/project/PublishAutoPlugin.scala
+++ b/project/PublishAutoPlugin.scala
@@ -2,27 +2,25 @@ import sbt._
 import sbt.Keys._
 import bintray.BintrayKeys._
 
-object PublishAutoPlugin extends AutoPlugin { 
-
+object PublishAutoPlugin extends AutoPlugin {
   override val trigger: PluginTrigger = allRequirements
 
   override val requires: Plugins = sbtrelease.ReleasePlugin
 
-  object autoImport {
-  }
+  object autoImport {}
 
- import autoImport._
+  import autoImport._
 
- override val projectSettings = Seq(
+  override val projectSettings = Seq(
     publishMavenStyle := true,
     pomExtraSetting("akka-persistence-jdbc"),
     homepageSetting("akka-persistence-jdbc"),
     bintrayPackageLabelsSettings("jdbc"),
-    bintrayPackageAttributesSettings("akka-persistence-jdbc")
- )
-  
-def pomExtraSetting(name: String) = pomExtra := 
-    <scm>
+    bintrayPackageAttributesSettings("akka-persistence-jdbc"))
+
+  def pomExtraSetting(name: String) =
+    pomExtra :=
+      <scm>
         <url>https://github.com/dnvriend/${name}</url>
         <connection>scm:git@github.com:dnvriend/${name}.git</connection>
         </scm>
@@ -34,17 +32,16 @@ def pomExtraSetting(name: String) = pomExtra :=
         </developer>
         </developers>
 
-    def homepageSetting(name: String) = 
-      homepage := Some(url(s"https://github.com/dnvriend/$name"))
+  def homepageSetting(name: String) =
+    homepage := Some(url(s"https://github.com/dnvriend/$name"))
 
-    def bintrayPackageLabelsSettings(labels: String*) = 
-	  bintrayPackageLabels := Seq("akka", "persistence") ++ labels
+  def bintrayPackageLabelsSettings(labels: String*) =
+    bintrayPackageLabels := Seq("akka", "persistence") ++ labels
 
-    def bintrayPackageAttributesSettings(name: String) = bintrayPackageAttributes ~=
-	  (_ ++ Map(
-	    "website_url" -> Seq(bintry.Attr.String(s"https://github.com/dnvriend/$name")),
-	    "github_repo" -> Seq(bintry.Attr.String(s"https://github.com/dnvriend/$name.git")),
-	    "issue_tracker_url" -> Seq(bintry.Attr.String(s"https://github.com/dnvriend/$name.git/issues/"))
-	  )
-)
+  def bintrayPackageAttributesSettings(name: String) =
+    bintrayPackageAttributes ~=
+      (_ ++ Map(
+        "website_url" -> Seq(bintry.Attr.String(s"https://github.com/dnvriend/$name")),
+        "github_repo" -> Seq(bintry.Attr.String(s"https://github.com/dnvriend/$name.git")),
+        "issue_tracker_url" -> Seq(bintry.Attr.String(s"https://github.com/dnvriend/$name.git/issues/"))))
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,14 +16,8 @@
 
 // to deploy to bintray
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
-
-// enable updating file headers eg. for copyright
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")
-
-// enable release process
-// https://github.com/sbt/sbt-release
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
-
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
-
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,9 +17,6 @@
 // to deploy to bintray
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 
-// to format scala source code
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
-
 // enable updating file headers eg. for copyright
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")
 

--- a/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
+++ b/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
@@ -111,14 +111,20 @@ class SnapshotConfig(config: Config) {
 }
 
 object JournalSequenceRetrievalConfig {
-  def apply(config: Config): JournalSequenceRetrievalConfig = JournalSequenceRetrievalConfig(
-    batchSize = config.asInt("journal-sequence-retrieval.batch-size", 10000),
-    maxTries = config.asInt("journal-sequence-retrieval.max-tries", 10),
-    queryDelay = config.asFiniteDuration("journal-sequence-retrieval.query-delay", 1.second),
-    maxBackoffQueryDelay = config.asFiniteDuration("journal-sequence-retrieval.max-backoff-query-delay", 1.minute),
-    askTimeout = config.asFiniteDuration("journal-sequence-retrieval.ask-timeout", 1.second))
+  def apply(config: Config): JournalSequenceRetrievalConfig =
+    JournalSequenceRetrievalConfig(
+      batchSize = config.asInt("journal-sequence-retrieval.batch-size", 10000),
+      maxTries = config.asInt("journal-sequence-retrieval.max-tries", 10),
+      queryDelay = config.asFiniteDuration("journal-sequence-retrieval.query-delay", 1.second),
+      maxBackoffQueryDelay = config.asFiniteDuration("journal-sequence-retrieval.max-backoff-query-delay", 1.minute),
+      askTimeout = config.asFiniteDuration("journal-sequence-retrieval.ask-timeout", 1.second))
 }
-case class JournalSequenceRetrievalConfig(batchSize: Int, maxTries: Int, queryDelay: FiniteDuration, maxBackoffQueryDelay: FiniteDuration, askTimeout: FiniteDuration)
+case class JournalSequenceRetrievalConfig(
+    batchSize: Int,
+    maxTries: Int,
+    queryDelay: FiniteDuration,
+    maxBackoffQueryDelay: FiniteDuration,
+    askTimeout: FiniteDuration)
 
 class ReadJournalConfig(config: Config) {
   val journalTableConfiguration = new JournalTableConfiguration(config)
@@ -129,5 +135,6 @@ class ReadJournalConfig(config: Config) {
   val addShutdownHook: Boolean = config.asBoolean("add-shutdown-hook", true)
   val includeDeleted: Boolean = config.as[Boolean]("includeLogicallyDeleted", true)
 
-  override def toString: String = s"ReadJournalConfig($journalTableConfiguration,$pluginConfig,$refreshInterval,$maxBufferSize,$addShutdownHook,$includeDeleted)"
+  override def toString: String =
+    s"ReadJournalConfig($journalTableConfiguration,$pluginConfig,$refreshInterval,$maxBufferSize,$addShutdownHook,$includeDeleted)"
 }

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializer.scala
@@ -24,21 +24,24 @@ import akka.serialization.Serialization
 import scala.collection.immutable._
 import scala.util.Try
 
-class ByteArrayJournalSerializer(serialization: Serialization, separator: String) extends FlowPersistentReprSerializer[JournalRow] {
+class ByteArrayJournalSerializer(serialization: Serialization, separator: String)
+    extends FlowPersistentReprSerializer[JournalRow] {
   override def serialize(persistentRepr: PersistentRepr, tags: Set[String]): Try[JournalRow] = {
     serialization
       .serialize(persistentRepr)
-      .map(JournalRow(
-        Long.MinValue,
-        persistentRepr.deleted,
-        persistentRepr.persistenceId,
-        persistentRepr.sequenceNr,
-        _,
-        encodeTags(tags, separator)))
+      .map(
+        JournalRow(
+          Long.MinValue,
+          persistentRepr.deleted,
+          persistentRepr.persistenceId,
+          persistentRepr.sequenceNr,
+          _,
+          encodeTags(tags, separator)))
   }
 
   override def deserialize(journalRow: JournalRow): Try[(PersistentRepr, Set[String], Long)] = {
-    serialization.deserialize(journalRow.message, classOf[PersistentRepr])
+    serialization
+      .deserialize(journalRow.message, classOf[PersistentRepr])
       .map((_, decodeTags(journalRow.tags, separator), journalRow.ordering))
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDao.scala
@@ -39,7 +39,11 @@ trait JournalDao {
   /**
    * Returns a Source of PersistentRepr for a certain persistenceId
    */
-  def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed]
+  def messages(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      max: Long): Source[Try[PersistentRepr], NotUsed]
 
   /**
    * @see [[akka.persistence.journal.AsyncWriteJournal.asyncWriteMessages(messages)]]

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/JournalTables.scala
@@ -26,15 +26,20 @@ trait JournalTables {
 
   def journalTableCfg: JournalTableConfiguration
 
-  class Journal(_tableTag: Tag) extends Table[JournalRow](_tableTag, _schemaName = journalTableCfg.schemaName, _tableName = journalTableCfg.tableName) {
-
+  class Journal(_tableTag: Tag)
+      extends Table[JournalRow](
+        _tableTag,
+        _schemaName = journalTableCfg.schemaName,
+        _tableName = journalTableCfg.tableName) {
     def * = (ordering, deleted, persistenceId, sequenceNumber, message, tags) <> (JournalRow.tupled, JournalRow.unapply)
 
     val ordering: Rep[Long] = column[Long](journalTableCfg.columnNames.ordering, O.AutoInc)
-    val persistenceId: Rep[String] = column[String](journalTableCfg.columnNames.persistenceId, O.Length(255, varying = true))
+    val persistenceId: Rep[String] =
+      column[String](journalTableCfg.columnNames.persistenceId, O.Length(255, varying = true))
     val sequenceNumber: Rep[Long] = column[Long](journalTableCfg.columnNames.sequenceNumber)
     val deleted: Rep[Boolean] = column[Boolean](journalTableCfg.columnNames.deleted, O.Default(false))
-    val tags: Rep[Option[String]] = column[Option[String]](journalTableCfg.columnNames.tags, O.Length(255, varying = true))
+    val tags: Rep[Option[String]] =
+      column[Option[String]](journalTableCfg.columnNames.tags, O.Length(255, varying = true))
     val message: Rep[Array[Byte]] = column[Array[Byte]](journalTableCfg.columnNames.message)
     val pk = primaryKey(s"${tableName}_pk", (persistenceId, sequenceNumber))
     val orderingIdx = index(s"${tableName}_ordering_idx", ordering, unique = true)

--- a/src/main/scala/akka/persistence/jdbc/journal/dao/package.scala
+++ b/src/main/scala/akka/persistence/jdbc/journal/dao/package.scala
@@ -24,5 +24,4 @@ package object dao {
 
   def decodeTags(tags: Option[String], separator: String): Set[String] =
     tags.map(_.split(separator).toSet).getOrElse(Set.empty[String])
-
 }

--- a/src/main/scala/akka/persistence/jdbc/package.scala
+++ b/src/main/scala/akka/persistence/jdbc/package.scala
@@ -17,5 +17,11 @@
 package akka.persistence
 
 package object jdbc {
-  final case class JournalRow(ordering: Long, deleted: Boolean, persistenceId: String, sequenceNumber: Long, message: Array[Byte], tags: Option[String] = None)
+  final case class JournalRow(
+      ordering: Long,
+      deleted: Boolean,
+      persistenceId: String,
+      sequenceNumber: Long,
+      message: Array[Byte],
+      tags: Option[String] = None)
 }

--- a/src/main/scala/akka/persistence/jdbc/query/JdbcReadJournalProvider.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/JdbcReadJournalProvider.scala
@@ -20,7 +20,8 @@ import akka.actor.ExtendedActorSystem
 import akka.persistence.query.ReadJournalProvider
 import com.typesafe.config.Config
 
-class JdbcReadJournalProvider(system: ExtendedActorSystem, config: Config, configPath: String) extends ReadJournalProvider {
+class JdbcReadJournalProvider(system: ExtendedActorSystem, config: Config, configPath: String)
+    extends ReadJournalProvider {
   override val scaladslReadJournal = new scaladsl.JdbcReadJournal(config, configPath)(system)
 
   override val javadslReadJournal = new javadsl.JdbcReadJournal(scaladslReadJournal)

--- a/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalDao.scala
@@ -36,12 +36,20 @@ trait ReadJournalDao {
    * the global ordering of the events.
    * Each element with be a try with a PersistentRepr, set of tags, and a Long representing the global ordering of events
    */
-  def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed]
+  def eventsByTag(
+      tag: String,
+      offset: Long,
+      maxOffset: Long,
+      max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed]
 
   /**
    * Returns a Source of bytes for a certain persistenceId
    */
-  def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed]
+  def messages(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      max: Long): Source[Try[PersistentRepr], NotUsed]
 
   /**
    * @param offset Minimum value to retrieve

--- a/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
@@ -26,24 +26,30 @@ object JdbcReadJournal {
   final val Identifier = ScalaJdbcReadJournal.Identifier
 }
 
-class JdbcReadJournal(journal: ScalaJdbcReadJournal) extends ReadJournal
-  with CurrentPersistenceIdsQuery
-  with PersistenceIdsQuery
-  with CurrentEventsByPersistenceIdQuery
-  with EventsByPersistenceIdQuery
-  with CurrentEventsByTagQuery
-  with EventsByTagQuery {
-
+class JdbcReadJournal(journal: ScalaJdbcReadJournal)
+    extends ReadJournal
+    with CurrentPersistenceIdsQuery
+    with PersistenceIdsQuery
+    with CurrentEventsByPersistenceIdQuery
+    with EventsByPersistenceIdQuery
+    with CurrentEventsByTagQuery
+    with EventsByTagQuery {
   override def currentPersistenceIds(): Source[String, NotUsed] =
     journal.currentPersistenceIds().asJava
 
   override def persistenceIds(): Source[String, NotUsed] =
     journal.persistenceIds().asJava
 
-  override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
+  override def currentEventsByPersistenceId(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     journal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
-  override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
+  override def eventsByPersistenceId(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     journal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**

--- a/src/main/scala/akka/persistence/jdbc/query/package.scala
+++ b/src/main/scala/akka/persistence/jdbc/query/package.scala
@@ -26,7 +26,9 @@ package object query {
     def value = that match {
       case Sequence(offsetValue) => offsetValue
       case NoOffset              => 0L
-      case _                     => throw new IllegalArgumentException("akka-persistence-jdbc does not support " + that.getClass.getName + " offsets")
+      case _ =>
+        throw new IllegalArgumentException(
+          "akka-persistence-jdbc does not support " + that.getClass.getName + " offsets")
     }
   }
 }

--- a/src/main/scala/akka/persistence/jdbc/serialization/PersistentReprSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/serialization/PersistentReprSerializer.scala
@@ -26,7 +26,6 @@ import scala.collection.immutable._
 import scala.util.Try
 
 trait PersistentReprSerializer[T] {
-
   /**
    * An akka.persistence.AtomicWrite contains a Sequence of events (with metadata, the PersistentRepr)
    * that must all be persisted or all fail, what makes the operation atomic. The function converts
@@ -52,11 +51,9 @@ trait PersistentReprSerializer[T] {
    * deserialize into a PersistentRepr, a set of tags and a Long representing the global ordering of events
    */
   def deserialize(t: T): Try[(PersistentRepr, Set[String], Long)]
-
 }
 
 trait FlowPersistentReprSerializer[T] extends PersistentReprSerializer[T] {
-
   /**
    * A flow which deserializes each element into a PersistentRepr,
    * a set of tags and a Long representing the global ordering of events

--- a/src/main/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStore.scala
@@ -33,7 +33,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 
 object JdbcSnapshotStore {
-
   def toSelectedSnapshot(tupled: (SnapshotMetadata, Any)): SelectedSnapshot = tupled match {
     case (meta: SnapshotMetadata, snapshot: Any) => SelectedSnapshot(meta, snapshot)
   }
@@ -67,8 +66,8 @@ class JdbcSnapshotStore(config: Config) extends SnapshotStore {
   }
 
   override def loadAsync(
-    persistenceId: String,
-    criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
+      persistenceId: String,
+      criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
     val result = criteria match {
       case SnapshotSelectionCriteria(Long.MaxValue, Long.MaxValue, _, _) =>
         snapshotDao.latestSnapshot(persistenceId)
@@ -87,9 +86,10 @@ class JdbcSnapshotStore(config: Config) extends SnapshotStore {
   override def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] =
     snapshotDao.save(metadata, snapshot)
 
-  override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = for {
-    _ <- snapshotDao.delete(metadata.persistenceId, metadata.sequenceNr)
-  } yield ()
+  override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] =
+    for {
+      _ <- snapshotDao.delete(metadata.persistenceId, metadata.sequenceNr)
+    } yield ()
 
   override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = criteria match {
     case SnapshotSelectionCriteria(Long.MaxValue, Long.MaxValue, _, _) =>

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotDao.scala
@@ -27,7 +27,12 @@ import slick.jdbc.JdbcBackend
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 
-class ByteArraySnapshotDao(db: JdbcBackend#Database, profile: JdbcProfile, snapshotConfig: SnapshotConfig, serialization: Serialization)(implicit ec: ExecutionContext, val mat: Materializer) extends SnapshotDao {
+class ByteArraySnapshotDao(
+    db: JdbcBackend#Database,
+    profile: JdbcProfile,
+    snapshotConfig: SnapshotConfig,
+    serialization: Serialization)(implicit ec: ExecutionContext, val mat: Materializer)
+    extends SnapshotDao {
   import profile.api._
 
   val queries = new SnapshotQueries(profile, snapshotConfig.snapshotTableConfiguration)
@@ -40,44 +45,69 @@ class ByteArraySnapshotDao(db: JdbcBackend#Database, profile: JdbcProfile, snaps
       case Failure(cause)        => throw cause
     }
 
-  override def latestSnapshot(persistenceId: String): Future[Option[(SnapshotMetadata, Any)]] = for {
-    rows <- db.run(queries.selectLatestByPersistenceId(persistenceId).result)
-  } yield rows.headOption map toSnapshotData
+  override def latestSnapshot(persistenceId: String): Future[Option[(SnapshotMetadata, Any)]] =
+    for {
+      rows <- db.run(queries.selectLatestByPersistenceId(persistenceId).result)
+    } yield rows.headOption.map(toSnapshotData)
 
-  override def snapshotForMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] = for {
-    rows <- db.run(queries.selectOneByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).result)
-  } yield rows.headOption map toSnapshotData
+  override def snapshotForMaxTimestamp(
+      persistenceId: String,
+      maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] =
+    for {
+      rows <- db.run(queries.selectOneByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).result)
+    } yield rows.headOption.map(toSnapshotData)
 
-  override def snapshotForMaxSequenceNr(persistenceId: String, maxSequenceNr: Long): Future[Option[(SnapshotMetadata, Any)]] = for {
-    rows <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).result)
-  } yield rows.headOption map toSnapshotData
+  override def snapshotForMaxSequenceNr(
+      persistenceId: String,
+      maxSequenceNr: Long): Future[Option[(SnapshotMetadata, Any)]] =
+    for {
+      rows <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).result)
+    } yield rows.headOption.map(toSnapshotData)
 
-  override def snapshotForMaxSequenceNrAndMaxTimestamp(persistenceId: String, maxSequenceNr: Long, maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] = for {
-    rows <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).result)
-  } yield rows.headOption map toSnapshotData
+  override def snapshotForMaxSequenceNrAndMaxTimestamp(
+      persistenceId: String,
+      maxSequenceNr: Long,
+      maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] =
+    for {
+      rows <- db.run(
+        queries
+          .selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp)
+          .result)
+    } yield rows.headOption.map(toSnapshotData)
 
   override def save(snapshotMetadata: SnapshotMetadata, snapshot: Any): Future[Unit] = {
     val eventualSnapshotRow = Future.fromTry(serializer.serialize(snapshotMetadata, snapshot))
     eventualSnapshotRow.map(queries.insertOrUpdate).flatMap(db.run).map(_ => ())
   }
 
-  override def delete(persistenceId: String, sequenceNr: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectByPersistenceIdAndSequenceNr(persistenceId, sequenceNr).delete)
-  } yield ()
+  override def delete(persistenceId: String, sequenceNr: Long): Future[Unit] =
+    for {
+      _ <- db.run(queries.selectByPersistenceIdAndSequenceNr(persistenceId, sequenceNr).delete)
+    } yield ()
 
-  override def deleteAllSnapshots(persistenceId: String): Future[Unit] = for {
-    _ <- db.run(queries.selectAll(persistenceId).delete)
-  } yield ()
+  override def deleteAllSnapshots(persistenceId: String): Future[Unit] =
+    for {
+      _ <- db.run(queries.selectAll(persistenceId).delete)
+    } yield ()
 
-  override def deleteUpToMaxSequenceNr(persistenceId: String, maxSequenceNr: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).delete)
-  } yield ()
+  override def deleteUpToMaxSequenceNr(persistenceId: String, maxSequenceNr: Long): Future[Unit] =
+    for {
+      _ <- db.run(queries.selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).delete)
+    } yield ()
 
-  override def deleteUpToMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectByPersistenceIdUpToMaxTimestamp(persistenceId, maxTimestamp).delete)
-  } yield ()
+  override def deleteUpToMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Unit] =
+    for {
+      _ <- db.run(queries.selectByPersistenceIdUpToMaxTimestamp(persistenceId, maxTimestamp).delete)
+    } yield ()
 
-  override def deleteUpToMaxSequenceNrAndMaxTimestamp(persistenceId: String, maxSequenceNr: Long, maxTimestamp: Long): Future[Unit] = for {
-    _ <- db.run(queries.selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).delete)
-  } yield ()
+  override def deleteUpToMaxSequenceNrAndMaxTimestamp(
+      persistenceId: String,
+      maxSequenceNr: Long,
+      maxTimestamp: Long): Future[Unit] =
+    for {
+      _ <- db.run(
+        queries
+          .selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp)
+          .delete)
+    } yield ()
 }

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotSerializer.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/ByteArraySnapshotSerializer.scala
@@ -25,7 +25,6 @@ import akka.serialization.Serialization
 import scala.util.Try
 
 class ByteArraySnapshotSerializer(serialization: Serialization) extends SnapshotSerializer[SnapshotRow] {
-
   def serialize(metadata: SnapshotMetadata, snapshot: Any): Try[SnapshotRow] = {
     serialization
       .serialize(Snapshot(snapshot))
@@ -36,12 +35,9 @@ class ByteArraySnapshotSerializer(serialization: Serialization) extends Snapshot
     serialization
       .deserialize(snapshotRow.snapshot, classOf[Snapshot])
       .map(snapshot => {
-        val snapshotMetadata = SnapshotMetadata(
-          snapshotRow.persistenceId,
-          snapshotRow.sequenceNumber,
-          snapshotRow.created)
+        val snapshotMetadata =
+          SnapshotMetadata(snapshotRow.persistenceId, snapshotRow.sequenceNumber, snapshotRow.created)
         (snapshotMetadata, snapshot.data)
       })
   }
-
 }

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotDao.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotDao.scala
@@ -27,7 +27,10 @@ trait SnapshotDao {
 
   def deleteUpToMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Unit]
 
-  def deleteUpToMaxSequenceNrAndMaxTimestamp(persistenceId: String, maxSequenceNr: Long, maxTimestamp: Long): Future[Unit]
+  def deleteUpToMaxSequenceNrAndMaxTimestamp(
+      persistenceId: String,
+      maxSequenceNr: Long,
+      maxTimestamp: Long): Future[Unit]
 
   def latestSnapshot(persistenceId: String): Future[Option[(SnapshotMetadata, Any)]]
 
@@ -35,7 +38,10 @@ trait SnapshotDao {
 
   def snapshotForMaxSequenceNr(persistenceId: String, sequenceNr: Long): Future[Option[(SnapshotMetadata, Any)]]
 
-  def snapshotForMaxSequenceNrAndMaxTimestamp(persistenceId: String, sequenceNr: Long, timestamp: Long): Future[Option[(SnapshotMetadata, Any)]]
+  def snapshotForMaxSequenceNrAndMaxTimestamp(
+      persistenceId: String,
+      sequenceNr: Long,
+      timestamp: Long): Future[Option[(SnapshotMetadata, Any)]]
 
   def delete(persistenceId: String, sequenceNr: Long): Future[Unit]
 

--- a/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
+++ b/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
@@ -20,7 +20,8 @@ import akka.persistence.jdbc.config.SnapshotTableConfiguration
 import akka.persistence.jdbc.snapshot.dao.SnapshotTables.SnapshotRow
 import slick.jdbc.JdbcProfile
 
-class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: SnapshotTableConfiguration) extends SnapshotTables {
+class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: SnapshotTableConfiguration)
+    extends SnapshotTables {
   import profile.api._
 
   private val SnapshotTableC = Compiled(SnapshotTable)
@@ -48,9 +49,13 @@ class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: S
     _selectAll(persistenceId).filter(_.sequenceNumber <= maxSequenceNr)
   val selectByPersistenceIdUpToMaxSequenceNr = Compiled(_selectByPersistenceIdUpToMaxSequenceNr _)
 
-  private def _selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp(persistenceId: Rep[String], maxSequenceNr: Rep[Long], maxTimestamp: Rep[Long]) =
+  private def _selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp(
+      persistenceId: Rep[String],
+      maxSequenceNr: Rep[Long],
+      maxTimestamp: Rep[Long]) =
     _selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp)
-  val selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp = Compiled(_selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp _)
+  val selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp = Compiled(
+    _selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp _)
 
   private def _selectOneByPersistenceIdAndMaxTimestamp(persistenceId: Rep[String], maxTimestamp: Rep[Long]) =
     _selectAll(persistenceId).filter(_.created <= maxTimestamp).take(1)
@@ -60,7 +65,11 @@ class SnapshotQueries(val profile: JdbcProfile, override val snapshotTableCfg: S
     _selectAll(persistenceId).filter(_.sequenceNumber <= maxSequenceNr).take(1)
   val selectOneByPersistenceIdAndMaxSequenceNr = Compiled(_selectOneByPersistenceIdAndMaxSequenceNr _)
 
-  private def _selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId: Rep[String], maxSequenceNr: Rep[Long], maxTimestamp: Rep[Long]) =
+  private def _selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(
+      persistenceId: Rep[String],
+      maxSequenceNr: Rep[Long],
+      maxTimestamp: Rep[Long]) =
     _selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).filter(_.created <= maxTimestamp).take(1)
-  val selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp = Compiled(_selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp _)
+  val selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp = Compiled(
+    _selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp _)
 }

--- a/src/main/scala/akka/persistence/jdbc/util/ConfigOps.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/ConfigOps.scala
@@ -31,37 +31,31 @@ object ConfigOps {
       Try(config.getAnyRef(key)).map(_.asInstanceOf[A])
 
     def as[A](key: String, default: A): A =
-      Try(config.getAnyRef(key)).map(_.asInstanceOf[A])
-        .getOrElse(default)
+      Try(config.getAnyRef(key)).map(_.asInstanceOf[A]).getOrElse(default)
 
     def asConfig(key: String, default: Config = ConfigFactory.empty) =
-      Try(config.getConfig(key))
-        .getOrElse(default)
+      Try(config.getConfig(key)).getOrElse(default)
 
     def asInt(key: String, default: Int): Int =
-      Try(config.getInt(key))
-        .getOrElse(default)
+      Try(config.getInt(key)).getOrElse(default)
 
     def asString(key: String, default: String): String =
-      Try(config.getString(key))
-        .getOrElse(default)
+      Try(config.getString(key)).getOrElse(default)
 
     def asOptionalNonEmptyString(key: String): Option[String] = {
       if (config.hasPath(key)) Some(config.getString(key)).filterNot(_.isEmpty) else None
     }
 
     def asBoolean(key: String, default: Boolean) =
-      Try(config.getBoolean(key))
-        .getOrElse(default)
+      Try(config.getBoolean(key)).getOrElse(default)
 
     def asFiniteDuration(key: String, default: FiniteDuration) =
-      Try(FiniteDuration(config.getDuration(key).toMillis, TimeUnit.MILLISECONDS))
-        .getOrElse(default)
+      Try(FiniteDuration(config.getDuration(key).toMillis, TimeUnit.MILLISECONDS)).getOrElse(default)
 
     def asDuration(key: String): Duration =
       config.getString(key).toLowerCase(Locale.ROOT) match {
         case "off" => Duration.Undefined
-        case _     => config.getMillisDuration(key) requiring (_ > Duration.Zero, key + " >0s, or off")
+        case _     => config.getMillisDuration(key).requiring(_ > Duration.Zero, key + " >0s, or off")
       }
 
     def getMillisDuration(key: String): FiniteDuration = getDuration(key, TimeUnit.MILLISECONDS)

--- a/src/main/scala/akka/persistence/jdbc/util/SlickDatabase.scala
+++ b/src/main/scala/akka/persistence/jdbc/util/SlickDatabase.scala
@@ -29,7 +29,6 @@ import slick.jdbc.JdbcBackend._
  */
 @deprecated(message = "Internal API, will be removed in 4.0.0", since = "3.4.0")
 object SlickDriver {
-
   /**
    * INTERNAL API
    */
@@ -42,7 +41,6 @@ object SlickDriver {
  * INTERNAL API
  */
 object SlickDatabase {
-
   /**
    * INTERNAL API
    */
@@ -64,8 +62,7 @@ object SlickDatabase {
     slickConfiguration.jndiName
       .map(Database.forName(_, None))
       .orElse {
-        slickConfiguration.jndiDbName.map(
-          new InitialContext().lookup(_).asInstanceOf[Database])
+        slickConfiguration.jndiDbName.map(new InitialContext().lookup(_).asInstanceOf[Database])
       }
       .getOrElse(Database.forConfig(path, config))
   }
@@ -73,11 +70,12 @@ object SlickDatabase {
   /**
    * INTERNAL API
    */
-  private[jdbc] def initializeEagerly(config: Config, slickConfiguration: SlickConfiguration, path: String): SlickDatabase = {
+  private[jdbc] def initializeEagerly(
+      config: Config,
+      slickConfiguration: SlickConfiguration,
+      path: String): SlickDatabase = {
     val dbPath = if (path.isEmpty) "db" else s"$path.db"
-    EagerSlickDatabase(
-      database(config, slickConfiguration, dbPath),
-      profile(config, path))
+    EagerSlickDatabase(database(config, slickConfiguration, dbPath), profile(config, path))
   }
 }
 
@@ -108,7 +106,6 @@ class LazySlickDatabase(config: Config, system: ActorSystem) extends SlickDataba
     val db = SlickDatabase.database(config, new SlickConfiguration(config), path = "db")
     system.registerOnTermination {
       db.close()
-
     }
     db
   }

--- a/src/test/scala/akka/persistence/jdbc/SharedActorSystemTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/SharedActorSystemTestSpec.scala
@@ -30,7 +30,6 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 abstract class SharedActorSystemTestSpec(val config: Config) extends SimpleSpec with DropCreate with BeforeAndAfterAll {
-
   def this(config: String = "postgres-application.conf", configOverrides: Map[String, ConfigValue] = Map.empty) =
     this(configOverrides.foldLeft(ConfigFactory.load(config)) {
       case (conf, (path, configValue)) => conf.withValue(path, configValue)

--- a/src/test/scala/akka/persistence/jdbc/SimpleSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/SimpleSpec.scala
@@ -22,24 +22,24 @@ import akka.testkit.TestProbe
 import org.scalatest._
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 
-trait SimpleSpec extends FlatSpec
-  with Matchers
-  with ScalaFutures
-  with TryValues
-  with OptionValues
-  with Eventually
-  with ClasspathResources
-  with BeforeAndAfterAll
-  with BeforeAndAfterEach
-  with GivenWhenThen {
-
+trait SimpleSpec
+    extends FlatSpec
+    with Matchers
+    with ScalaFutures
+    with TryValues
+    with OptionValues
+    with Eventually
+    with ClasspathResources
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with GivenWhenThen {
   /**
    * Sends the PoisonPill command to an actor and waits for it to die
    */
   def killActors(actors: ActorRef*)(implicit system: ActorSystem): Unit = {
     val tp = TestProbe()
     actors.foreach { (actor: ActorRef) =>
-      tp watch actor
+      tp.watch(actor)
       system.stop(actor)
       tp.expectTerminated(actor)
     }

--- a/src/test/scala/akka/persistence/jdbc/SingleActorSystemPerTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/SingleActorSystemPerTestSpec.scala
@@ -27,8 +27,10 @@ import slick.jdbc.JdbcBackend.Database
 
 import scala.concurrent.duration._
 
-abstract class SingleActorSystemPerTestSpec(val config: Config) extends SimpleSpec with DropCreate with BeforeAndAfterEach {
-
+abstract class SingleActorSystemPerTestSpec(val config: Config)
+    extends SimpleSpec
+    with DropCreate
+    with BeforeAndAfterEach {
   def this(config: String = "postgres-application.conf", configOverrides: Map[String, ConfigValue] = Map.empty) =
     this(configOverrides.foldLeft(ConfigFactory.load(config)) {
       case (conf, (path, configValue)) => conf.withValue(path, configValue)
@@ -50,7 +52,11 @@ abstract class SingleActorSystemPerTestSpec(val config: Config) extends SimpleSp
     dbOpt.getOrElse {
       val newDb = if (cfg.hasPath("slick.profile")) {
         SlickDatabase.database(cfg, new SlickConfiguration(cfg.getConfig("slick")), "slick.db")
-      } else SlickDatabase.database(config, new SlickConfiguration(config.getConfig("akka-persistence-jdbc.shared-databases.slick")), "akka-persistence-jdbc.shared-databases.slick.db")
+      } else
+        SlickDatabase.database(
+          config,
+          new SlickConfiguration(config.getConfig("akka-persistence-jdbc.shared-databases.slick")),
+          "akka-persistence-jdbc.shared-databases.slick.db")
 
       dbOpt = Some(newDb)
       newDb

--- a/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
@@ -21,7 +21,6 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.{ FlatSpec, Matchers }
 
 abstract class TablesTestSpec extends FlatSpec with Matchers {
-
   def toColumnName[A](tableName: String)(columnName: String): String = s"$tableName.$columnName"
 
   val config = ConfigFactory.parseString(

--- a/src/test/scala/akka/persistence/jdbc/configuration/ConfigOpsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/configuration/ConfigOpsTest.scala
@@ -23,8 +23,7 @@ import com.typesafe.config.ConfigFactory
 
 class ConfigOpsTest extends SimpleSpec {
   it should "parse field values to Try[A]" in {
-    val cfg = ConfigFactory.parseString(
-      """
+    val cfg = ConfigFactory.parseString("""
         | person {
         |   firstName = "foo"
         |   lastName = "bar"
@@ -51,8 +50,7 @@ class ConfigOpsTest extends SimpleSpec {
   }
 
   it should "parse field values with default values for wrong config" in {
-    val cfg = ConfigFactory.parseString(
-      """
+    val cfg = ConfigFactory.parseString("""
         | RedShirt {
         |   firstName = "red"
         |   lastName = "shirt"
@@ -70,8 +68,7 @@ class ConfigOpsTest extends SimpleSpec {
   }
 
   it should "parse field values to with defaults" in {
-    val cfg = ConfigFactory.parseString(
-      """
+    val cfg = ConfigFactory.parseString("""
         | person {
         |   age = 25
         |   hasGirlfriend = true
@@ -84,5 +81,4 @@ class ConfigOpsTest extends SimpleSpec {
     cfg.as[Boolean]("person.hasCar", false) shouldBe false
     cfg.as[Boolean]("person.hasGirlfriend", false) shouldBe true
   }
-
 }

--- a/src/test/scala/akka/persistence/jdbc/configuration/JNDIConfigTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/configuration/JNDIConfigTest.scala
@@ -6,7 +6,6 @@ import akka.persistence.jdbc.util.SlickExtension
 import com.typesafe.config.ConfigFactory
 
 class JNDIConfigTest extends SimpleSpec {
-
   "JNDI config" should "read the config and throw NoInitialContextException in case the JNDI resource is not available" in {
     withActorSystem("jndi-application.conf") { system =>
       val jdbcJournalConfig = system.settings.config.getConfig("jdbc-journal")
@@ -41,5 +40,4 @@ class JNDIConfigTest extends SimpleSpec {
       system.terminate().futureValue
     }
   }
-
 }

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
@@ -30,13 +30,13 @@ import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 
 import scala.concurrent.duration._
 
-abstract class JdbcJournalPerfSpec(config: Config, schemaType: SchemaType) extends JournalPerfSpec(config)
-  with BeforeAndAfterAll
-  with BeforeAndAfterEach
-  with ScalaFutures
-  with ClasspathResources
-  with DropCreate {
-
+abstract class JdbcJournalPerfSpec(config: Config, schemaType: SchemaType)
+    extends JournalPerfSpec(config)
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with ScalaFutures
+    with ClasspathResources
+    with DropCreate {
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = true
 
   implicit lazy val ec = system.dispatcher
@@ -73,7 +73,8 @@ abstract class JdbcJournalPerfSpec(config: Config, schemaType: SchemaType) exten
     s"measure: persist()-ing $eventsCount events for $actorCount actors" in {
       val testProbe = TestProbe()
       val replyAfter = eventsCount
-      def createBenchActor(actorNumber: Int) = system.actorOf(Props(classOf[BenchActor], s"$pid--$actorNumber", testProbe.ref, replyAfter))
+      def createBenchActor(actorNumber: Int) =
+        system.actorOf(Props(classOf[BenchActor], s"$pid--$actorNumber", testProbe.ref, replyAfter))
       val actors = 1.to(actorCount).map(createBenchActor)
 
       measure(d => s"Persist()-ing $eventsCount * $actorCount took ${d.toMillis} ms") {
@@ -94,7 +95,8 @@ abstract class JdbcJournalPerfSpec(config: Config, schemaType: SchemaType) exten
     s"measure: persistAsync()-ing $eventsCount events for $actorCount actors" in {
       val testProbe = TestProbe()
       val replyAfter = eventsCount
-      def createBenchActor(actorNumber: Int) = system.actorOf(Props(classOf[BenchActor], s"$pid--$actorNumber", testProbe.ref, replyAfter))
+      def createBenchActor(actorNumber: Int) =
+        system.actorOf(Props(classOf[BenchActor], s"$pid--$actorNumber", testProbe.ref, replyAfter))
       val actors = 1.to(actorCount).map(createBenchActor)
 
       measure(d => s"persistAsync()-ing $eventsCount * $actorCount took ${d.toMillis} ms") {
@@ -116,7 +118,8 @@ class PostgresJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("po
   override def eventsCount: Int = 100
 }
 
-class PostgresJournalPerfSpecSharedDb extends JdbcJournalPerfSpec(ConfigFactory.load("postgres-shared-db-application.conf"), Postgres()) {
+class PostgresJournalPerfSpecSharedDb
+    extends JdbcJournalPerfSpec(ConfigFactory.load("postgres-shared-db-application.conf"), Postgres()) {
   override def eventsCount: Int = 100
 }
 
@@ -128,7 +131,8 @@ class MySQLJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("mysql
   override def eventsCount: Int = 100
 }
 
-class MySQLJournalPerfSpecSharedDb extends JdbcJournalPerfSpec(ConfigFactory.load("mysql-shared-db-application.conf"), MySQL()) {
+class MySQLJournalPerfSpecSharedDb
+    extends JdbcJournalPerfSpec(ConfigFactory.load("mysql-shared-db-application.conf"), MySQL()) {
   override def eventsCount: Int = 100
 }
 
@@ -140,7 +144,8 @@ class OracleJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("orac
   override def eventsCount: Int = 100
 }
 
-class OracleJournalPerfSpecSharedDb extends JdbcJournalPerfSpec(ConfigFactory.load("oracle-shared-db-application.conf"), Oracle()) {
+class OracleJournalPerfSpecSharedDb
+    extends JdbcJournalPerfSpec(ConfigFactory.load("oracle-shared-db-application.conf"), Oracle()) {
   override def eventsCount: Int = 100
 }
 
@@ -148,11 +153,13 @@ class OracleJournalPerfSpecPhysicalDelete extends OracleJournalPerfSpec {
   this.cfg.withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false))
 }
 
-class SqlServerJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("sqlserver-application.conf"), SqlServer()) {
+class SqlServerJournalPerfSpec
+    extends JdbcJournalPerfSpec(ConfigFactory.load("sqlserver-application.conf"), SqlServer()) {
   override def eventsCount: Int = 100
 }
 
-class SqlServerJournalPerfSpecSharedDb extends JdbcJournalPerfSpec(ConfigFactory.load("sqlserver-shared-db-application.conf"), SqlServer()) {
+class SqlServerJournalPerfSpecSharedDb
+    extends JdbcJournalPerfSpec(ConfigFactory.load("sqlserver-shared-db-application.conf"), SqlServer()) {
   override def eventsCount: Int = 100
 }
 

--- a/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
@@ -27,13 +27,13 @@ import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 
 import scala.concurrent.duration._
 
-abstract class JdbcJournalSpec(config: Config, schemaType: SchemaType) extends JournalSpec(config)
-  with BeforeAndAfterAll
-  with BeforeAndAfterEach
-  with ScalaFutures
-  with ClasspathResources
-  with DropCreate {
-
+abstract class JdbcJournalSpec(config: Config, schemaType: SchemaType)
+    extends JournalSpec(config)
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with ScalaFutures
+    with ClasspathResources
+    with DropCreate {
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = true
 
   implicit val pc: PatienceConfig = PatienceConfig(timeout = 10.seconds)
@@ -58,26 +58,49 @@ abstract class JdbcJournalSpec(config: Config, schemaType: SchemaType) extends J
 }
 
 class PostgresJournalSpec extends JdbcJournalSpec(ConfigFactory.load("postgres-application.conf"), Postgres())
-class PostgresJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("postgres-shared-db-application.conf"), Postgres())
-class PostgresJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("postgres-application.conf")
-  .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), Postgres())
+class PostgresJournalSpecSharedDb
+    extends JdbcJournalSpec(ConfigFactory.load("postgres-shared-db-application.conf"), Postgres())
+class PostgresJournalSpecPhysicalDelete
+    extends JdbcJournalSpec(
+      ConfigFactory
+        .load("postgres-application.conf")
+        .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)),
+      Postgres())
 
 class MySQLJournalSpec extends JdbcJournalSpec(ConfigFactory.load("mysql-application.conf"), MySQL())
 class MySQLJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("mysql-shared-db-application.conf"), MySQL())
-class MySQLJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("mysql-application.conf")
-  .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), MySQL())
+class MySQLJournalSpecPhysicalDelete
+    extends JdbcJournalSpec(
+      ConfigFactory
+        .load("mysql-application.conf")
+        .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)),
+      MySQL())
 
 class OracleJournalSpec extends JdbcJournalSpec(ConfigFactory.load("oracle-application.conf"), Oracle())
-class OracleJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("oracle-shared-db-application.conf"), Oracle())
-class OracleJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("oracle-application.conf")
-  .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), Oracle())
+class OracleJournalSpecSharedDb
+    extends JdbcJournalSpec(ConfigFactory.load("oracle-shared-db-application.conf"), Oracle())
+class OracleJournalSpecPhysicalDelete
+    extends JdbcJournalSpec(
+      ConfigFactory
+        .load("oracle-application.conf")
+        .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)),
+      Oracle())
 
 class SqlServerJournalSpec extends JdbcJournalSpec(ConfigFactory.load("sqlserver-application.conf"), SqlServer())
-class SqlServerJournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("sqlserver-shared-db-application.conf"), SqlServer())
-class SqlServerJournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("sqlserver-application.conf")
-  .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), SqlServer())
+class SqlServerJournalSpecSharedDb
+    extends JdbcJournalSpec(ConfigFactory.load("sqlserver-shared-db-application.conf"), SqlServer())
+class SqlServerJournalSpecPhysicalDelete
+    extends JdbcJournalSpec(
+      ConfigFactory
+        .load("sqlserver-application.conf")
+        .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)),
+      SqlServer())
 
 class H2JournalSpec extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf"), H2())
 class H2JournalSpecSharedDb extends JdbcJournalSpec(ConfigFactory.load("h2-shared-db-application.conf"), H2())
-class H2JournalSpecPhysicalDelete extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf")
-  .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)), H2())
+class H2JournalSpecPhysicalDelete
+    extends JdbcJournalSpec(
+      ConfigFactory
+        .load("h2-application.conf")
+        .withValue("jdbc-journal.logicalDelete", ConfigValueFactory.fromAnyRef(false)),
+      H2())

--- a/src/test/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializerTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializerTest.scala
@@ -23,12 +23,11 @@ import akka.serialization.SerializationExtension
 import scala.collection.immutable._
 
 class ByteArrayJournalSerializerTest extends SharedActorSystemTestSpec() {
-
   it should "serialize a serializable message and indicate whether or not the serialization succeeded" in {
     val serializer = new ByteArrayJournalSerializer(serialization, ",")
     val result = serializer.serialize(Seq(AtomicWrite(PersistentRepr("foo"))))
     result should have size 1
-    result.head should be a Symbol("success")
+    (result.head should be).a(Symbol("success"))
   }
 
   it should "not serialize a non-serializable message and indicate whether or not the serialization succeeded" in {
@@ -36,7 +35,7 @@ class ByteArrayJournalSerializerTest extends SharedActorSystemTestSpec() {
     val serializer = new ByteArrayJournalSerializer(serialization, ",")
     val result = serializer.serialize(Seq(AtomicWrite(PersistentRepr(new Test))))
     result should have size 1
-    result.head should be a Symbol("failure")
+    (result.head should be).a(Symbol("failure"))
   }
 
   it should "serialize non-serializable and serializable messages and indicate whether or not the serialization succeeded" in {
@@ -44,7 +43,7 @@ class ByteArrayJournalSerializerTest extends SharedActorSystemTestSpec() {
     val serializer = new ByteArrayJournalSerializer(serialization, ",")
     val result = serializer.serialize(List(AtomicWrite(PersistentRepr(new Test)), AtomicWrite(PersistentRepr("foo"))))
     result should have size 2
-    result.head should be a Symbol("failure")
-    result.last should be a Symbol("success")
+    (result.head should be).a(Symbol("failure"))
+    (result.last should be).a(Symbol("success"))
   }
 }

--- a/src/test/scala/akka/persistence/jdbc/journal/dao/JournalTablesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/dao/JournalTablesTest.scala
@@ -20,7 +20,6 @@ import akka.persistence.jdbc.TablesTestSpec
 import slick.jdbc.JdbcProfile
 
 class JournalTablesTest extends TablesTestSpec {
-
   val journalTableConfiguration = journalConfig.journalTableConfiguration
 
   object TestByteAJournalTables extends JournalTables {
@@ -38,9 +37,12 @@ class JournalTablesTest extends TablesTestSpec {
 
   it should "be configured with column names" in {
     val colName = toColumnName(journalTableConfiguration.tableName)(_)
-    TestByteAJournalTables.JournalTable.baseTableRow.persistenceId.toString shouldBe colName(journalTableConfiguration.columnNames.persistenceId)
-    TestByteAJournalTables.JournalTable.baseTableRow.deleted.toString shouldBe colName(journalTableConfiguration.columnNames.deleted)
-    TestByteAJournalTables.JournalTable.baseTableRow.sequenceNumber.toString shouldBe colName(journalTableConfiguration.columnNames.sequenceNumber)
+    TestByteAJournalTables.JournalTable.baseTableRow.persistenceId.toString shouldBe colName(
+      journalTableConfiguration.columnNames.persistenceId)
+    TestByteAJournalTables.JournalTable.baseTableRow.deleted.toString shouldBe colName(
+      journalTableConfiguration.columnNames.deleted)
+    TestByteAJournalTables.JournalTable.baseTableRow.sequenceNumber.toString shouldBe colName(
+      journalTableConfiguration.columnNames.sequenceNumber)
     //    TestByteAJournalTables.JournalTable.baseTableRow.tags.toString() shouldBe colName(journalTableConfiguration.columnNames.tags)
   }
 }

--- a/src/test/scala/akka/persistence/jdbc/journal/dao/TagsSerializationTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/dao/TagsSerializationTest.scala
@@ -19,7 +19,6 @@ package akka.persistence.jdbc.journal.dao
 import akka.persistence.jdbc.SharedActorSystemTestSpec
 
 class TagsSerializationTest extends SharedActorSystemTestSpec {
-
   "Encode" should "no tags" in {
     encodeTags(Set.empty[String], ",") shouldBe None
   }

--- a/src/test/scala/akka/persistence/jdbc/journal/dao/TrySeqTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/journal/dao/TrySeqTest.scala
@@ -23,7 +23,6 @@ import scala.collection.immutable._
 import scala.util.{ Failure, Success }
 
 class TrySeqTest extends SimpleSpec {
-
   def failure(text: String) = Failure(new RuntimeException(text))
 
   it should "sequence an empty immutable.Seq" in {

--- a/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
@@ -70,6 +70,8 @@ class MySQLScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("mysql-appli
 
 class OracleScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("oracle-application.conf") with OracleCleaner
 
-class SqlServerScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("sqlserver-application.conf") with SqlServerCleaner
+class SqlServerScalaAllPersistenceIdsTest
+    extends AllPersistenceIdsTest("sqlserver-application.conf")
+    with SqlServerCleaner
 
 class H2ScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("h2-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
@@ -23,7 +23,6 @@ import akka.persistence.query.{ EventEnvelope, Sequence }
 import akka.testkit.TestProbe
 
 abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTestSpec(config) {
-
   it should "not find any events for unknown pid" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     journalOps.withCurrentEventsByPersistenceId()("unkown-pid", 0L, Long.MaxValue) { tp =>
@@ -112,21 +111,15 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
-        tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-          .expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1)).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
-        tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
-          .expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2)).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
-        tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
-          .expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3)).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
@@ -178,12 +171,22 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
 
 // Note: these tests use the shared-db configs, the test for all (so not only current) events use the regular db config
 
-class PostgresScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("postgres-shared-db-application.conf") with PostgresCleaner
+class PostgresScalaCurrentEventsByPersistenceIdTest
+    extends CurrentEventsByPersistenceIdTest("postgres-shared-db-application.conf")
+    with PostgresCleaner
 
-class MySQLScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("mysql-shared-db-application.conf") with MysqlCleaner
+class MySQLScalaCurrentEventsByPersistenceIdTest
+    extends CurrentEventsByPersistenceIdTest("mysql-shared-db-application.conf")
+    with MysqlCleaner
 
-class OracleScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("oracle-shared-db-application.conf") with OracleCleaner
+class OracleScalaCurrentEventsByPersistenceIdTest
+    extends CurrentEventsByPersistenceIdTest("oracle-shared-db-application.conf")
+    with OracleCleaner
 
-class SqlServerScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("sqlserver-shared-db-application.conf") with SqlServerCleaner
+class SqlServerScalaCurrentEventsByPersistenceIdTest
+    extends CurrentEventsByPersistenceIdTest("sqlserver-shared-db-application.conf")
+    with SqlServerCleaner
 
-class H2ScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("h2-shared-db-application.conf") with H2Cleaner
+class H2ScalaCurrentEventsByPersistenceIdTest
+    extends CurrentEventsByPersistenceIdTest("h2-shared-db-application.conf")
+    with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
@@ -17,7 +17,6 @@
 package akka.persistence.jdbc.query
 
 abstract class CurrentPersistenceIdsTest(config: String) extends QueryTestSpec(config) {
-
   it should "not find any persistenceIds for empty journal" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     journalOps.withCurrentPersistenceIds() { tp =>
@@ -46,12 +45,20 @@ abstract class CurrentPersistenceIdsTest(config: String) extends QueryTestSpec(c
 
 // Note: these tests use the shared-db configs, the test for all persistence ids use the regular db config
 
-class PostgresScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("postgres-shared-db-application.conf") with PostgresCleaner
+class PostgresScalaCurrentPersistenceIdsTest
+    extends CurrentPersistenceIdsTest("postgres-shared-db-application.conf")
+    with PostgresCleaner
 
-class MySQLScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("mysql-shared-db-application.conf") with MysqlCleaner
+class MySQLScalaCurrentPersistenceIdsTest
+    extends CurrentPersistenceIdsTest("mysql-shared-db-application.conf")
+    with MysqlCleaner
 
-class OracleScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("oracle-shared-db-application.conf") with OracleCleaner
+class OracleScalaCurrentPersistenceIdsTest
+    extends CurrentPersistenceIdsTest("oracle-shared-db-application.conf")
+    with OracleCleaner
 
-class SqlServerScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("sqlserver-application.conf") with SqlServerCleaner
+class SqlServerScalaCurrentPersistenceIdsTest
+    extends CurrentPersistenceIdsTest("sqlserver-application.conf")
+    with SqlServerCleaner
 
 class H2ScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("h2-shared-db-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -23,7 +23,6 @@ import akka.pattern.ask
 import akka.persistence.journal.{ EventSeq, ReadEventAdapter, Tagged, WriteEventAdapter }
 
 object EventAdapterTest {
-
   case class Event(value: String) {
     def adapted = EventAdapted(value)
   }
@@ -54,8 +53,8 @@ object EventAdapterTest {
       case _                               => event
     }
   }
-
 }
+
 /**
  * Tests that check persistence queries when event adapter is configured for persisted event.
  */
@@ -81,13 +80,11 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
         tp.cancel()
       }
     }
-
   }
 
   it should "apply event adapters when querying events by tag from an offset" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
-
       (actor1 ? TaggedEvent(Event("1"), "event")).futureValue
       (actor2 ? TaggedEvent(Event("2"), "event")).futureValue
       (actor3 ? TaggedEvent(Event("3"), "event")).futureValue
@@ -97,7 +94,6 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
       }
 
       journalOps.withEventsByTag(10.seconds)("event", Sequence(1)) { tp =>
-
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, EventRestored("2")))
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, EventRestored("3")))
@@ -123,21 +119,15 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
-        tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1")))
-          .expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1"))).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
-        tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2")))
-          .expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2"))).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
-        tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, EventRestored("3")))
-          .expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(3), "my-1", 3, EventRestored("3"))).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
@@ -195,7 +185,6 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
       }
     }
   }
-
 }
 
 class PostgresScalaEventAdapterTest extends EventAdapterTest("postgres-application.conf") with PostgresCleaner

--- a/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -24,7 +24,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(config) {
-
   it should "not find any events for unknown pid" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     journalOps.withEventsByPersistenceId()("unkown-pid", 0L, Long.MaxValue) { tp =>
@@ -150,34 +149,35 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
     }
   }
 
-  it should "find events for actor with pid 'my-1' and persisting messages to other actor" in withActorSystem { implicit system =>
-    val journalOps = new JavaDslJdbcReadJournalOperations(system)
-    withTestActors() { (actor1, actor2, actor3) =>
-      journalOps.withEventsByPersistenceId()("my-1", 0, Long.MaxValue) { tp =>
-        tp.request(10)
-        tp.expectNoMessage(100.millis)
+  it should "find events for actor with pid 'my-1' and persisting messages to other actor" in withActorSystem {
+    implicit system =>
+      val journalOps = new JavaDslJdbcReadJournalOperations(system)
+      withTestActors() { (actor1, actor2, actor3) =>
+        journalOps.withEventsByPersistenceId()("my-1", 0, Long.MaxValue) { tp =>
+          tp.request(10)
+          tp.expectNoMessage(100.millis)
 
-        actor1 ! 1
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNoMessage(100.millis)
+          actor1 ! 1
+          tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(1), "my-1", 1, 1))
+          tp.expectNoMessage(100.millis)
 
-        actor1 ! 2
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(2), "my-1", 2, 2))
-        tp.expectNoMessage(100.millis)
+          actor1 ! 2
+          tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(2), "my-1", 2, 2))
+          tp.expectNoMessage(100.millis)
 
-        actor2 ! 1
-        actor2 ! 2
-        actor2 ! 3
-        tp.expectNoMessage(100.millis)
+          actor2 ! 1
+          actor2 ! 2
+          actor2 ! 3
+          tp.expectNoMessage(100.millis)
 
-        actor1 ! 3
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(3), "my-1", 3, 3))
-        tp.expectNoMessage(100.millis)
+          actor1 ! 3
+          tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(3), "my-1", 3, 3))
+          tp.expectNoMessage(100.millis)
 
-        tp.cancel()
-        tp.expectNoMessage(100.millis)
+          tp.cancel()
+          tp.expectNoMessage(100.millis)
+        }
       }
-    }
   }
 
   it should "find events for actor with pid 'my-2'" in withActorSystem { implicit system =>
@@ -248,12 +248,18 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
   }
 }
 
-class PostgresScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("postgres-application.conf") with PostgresCleaner
+class PostgresScalaEventsByPersistenceIdTest
+    extends EventsByPersistenceIdTest("postgres-application.conf")
+    with PostgresCleaner
 
 class MySQLScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("mysql-application.conf") with MysqlCleaner
 
-class OracleScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("oracle-application.conf") with OracleCleaner
+class OracleScalaEventsByPersistenceIdTest
+    extends EventsByPersistenceIdTest("oracle-application.conf")
+    with OracleCleaner
 
-class SqlServerScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("sqlserver-application.conf") with SqlServerCleaner
+class SqlServerScalaEventsByPersistenceIdTest
+    extends EventsByPersistenceIdTest("sqlserver-application.conf")
+    with SqlServerCleaner
 
 class H2ScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("h2-application.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/HardDeleteQueryTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/HardDeleteQueryTest.scala
@@ -9,7 +9,6 @@ import org.scalatest.Matchers
 import scala.concurrent.duration._
 
 abstract class HardDeleteQueryTest(config: String) extends QueryTestSpec(config) with Matchers {
-
   implicit val askTimeout = 500.millis
 
   it should "not return deleted events when using CurrentEventsByTag" in withActorSystem { implicit system =>
@@ -29,7 +28,6 @@ abstract class HardDeleteQueryTest(config: String) extends QueryTestSpec(config)
         tp.request(Int.MaxValue)
         tp.expectComplete()
       }
-
     }
   }
 
@@ -50,7 +48,6 @@ abstract class HardDeleteQueryTest(config: String) extends QueryTestSpec(config)
         tp.request(Int.MaxValue)
         tp.cancel()
       }
-
     }
   }
 
@@ -71,7 +68,6 @@ abstract class HardDeleteQueryTest(config: String) extends QueryTestSpec(config)
         tp.request(Int.MaxValue)
         tp.expectComplete()
       }
-
     }
   }
 
@@ -92,17 +88,22 @@ abstract class HardDeleteQueryTest(config: String) extends QueryTestSpec(config)
         tp.request(Int.MaxValue)
         tp.cancel()
       }
-
     }
   }
 }
 
-class PostgresHardDeleteQueryTest extends HardDeleteQueryTest("postgres-application-with-hard-delete.conf") with PostgresCleaner
+class PostgresHardDeleteQueryTest
+    extends HardDeleteQueryTest("postgres-application-with-hard-delete.conf")
+    with PostgresCleaner
 
 class MySQLHardDeleteQueryTest extends HardDeleteQueryTest("mysql-application-with-hard-delete.conf") with MysqlCleaner
 
-class OracleHardDeleteQueryTest extends HardDeleteQueryTest("oracle-application-with-hard-delete.conf") with OracleCleaner
+class OracleHardDeleteQueryTest
+    extends HardDeleteQueryTest("oracle-application-with-hard-delete.conf")
+    with OracleCleaner
 
-class SqlServerHardDeleteQueryTest extends HardDeleteQueryTest("sqlserver-application-with-hard-delete.conf") with SqlServerCleaner
+class SqlServerHardDeleteQueryTest
+    extends HardDeleteQueryTest("sqlserver-application-with-hard-delete.conf")
+    with SqlServerCleaner
 
 class H2HardDeleteQueryTest extends HardDeleteQueryTest("h2-application-with-hard-delete.conf") with H2Cleaner

--- a/src/test/scala/akka/persistence/jdbc/query/LogicalDeleteQueryTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/LogicalDeleteQueryTest.scala
@@ -5,91 +5,90 @@ import akka.pattern._
 import scala.concurrent.duration._
 
 abstract class LogicalDeleteQueryTest(config: String) extends QueryTestSpec(config) {
-
   implicit val askTimeout = 500.millis
 
-  it should "return logically deleted events when using CurrentEventsByTag (backward compatibility)" in withActorSystem { implicit system =>
-    val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors(replyToMessages = true) { (actor1, _, _) =>
-      (actor1 ? withTags(1, "number")).futureValue
-      (actor1 ? withTags(2, "number")).futureValue
-      (actor1 ? withTags(3, "number")).futureValue
+  it should "return logically deleted events when using CurrentEventsByTag (backward compatibility)" in withActorSystem {
+    implicit system =>
+      val journalOps = new ScalaJdbcReadJournalOperations(system)
+      withTestActors(replyToMessages = true) { (actor1, _, _) =>
+        (actor1 ? withTags(1, "number")).futureValue
+        (actor1 ? withTags(2, "number")).futureValue
+        (actor1 ? withTags(3, "number")).futureValue
 
-      // delete and wait for confirmation
-      (actor1 ? DeleteCmd(1)).futureValue
+        // delete and wait for confirmation
+        (actor1 ? DeleteCmd(1)).futureValue
 
-      journalOps.withCurrentEventsByTag()("number", NoOffset) { tp =>
-        tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
-        tp.expectComplete()
+        journalOps.withCurrentEventsByTag()("number", NoOffset) { tp =>
+          tp.request(Int.MaxValue)
+          tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
+          tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
+          tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
+          tp.expectComplete()
+        }
       }
-
-    }
   }
 
-  it should "return logically deleted events when using EventsByTag (backward compatibility)" in withActorSystem { implicit system =>
-    val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors(replyToMessages = true) { (actor1, _, _) =>
-      (actor1 ? withTags(1, "number")).futureValue
-      (actor1 ? withTags(2, "number")).futureValue
-      (actor1 ? withTags(3, "number")).futureValue
+  it should "return logically deleted events when using EventsByTag (backward compatibility)" in withActorSystem {
+    implicit system =>
+      val journalOps = new ScalaJdbcReadJournalOperations(system)
+      withTestActors(replyToMessages = true) { (actor1, _, _) =>
+        (actor1 ? withTags(1, "number")).futureValue
+        (actor1 ? withTags(2, "number")).futureValue
+        (actor1 ? withTags(3, "number")).futureValue
 
-      // delete and wait for confirmation
-      (actor1 ? DeleteCmd(1)).futureValue shouldBe "deleted-1"
+        // delete and wait for confirmation
+        (actor1 ? DeleteCmd(1)).futureValue shouldBe "deleted-1"
 
-      journalOps.withEventsByTag()("number", NoOffset) { tp =>
-        tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
-        tp.cancel()
+        journalOps.withEventsByTag()("number", NoOffset) { tp =>
+          tp.request(Int.MaxValue)
+          tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
+          tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
+          tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
+          tp.cancel()
+        }
       }
-
-    }
   }
 
-  it should "return logically deleted events when using CurrentEventsByPersistenceId (backward compatibility)" in withActorSystem { implicit system =>
-    val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors(replyToMessages = true) { (actor1, _, _) =>
-      (actor1 ? withTags(1, "number")).futureValue
-      (actor1 ? withTags(2, "number")).futureValue
-      (actor1 ? withTags(3, "number")).futureValue
+  it should "return logically deleted events when using CurrentEventsByPersistenceId (backward compatibility)" in withActorSystem {
+    implicit system =>
+      val journalOps = new ScalaJdbcReadJournalOperations(system)
+      withTestActors(replyToMessages = true) { (actor1, _, _) =>
+        (actor1 ? withTags(1, "number")).futureValue
+        (actor1 ? withTags(2, "number")).futureValue
+        (actor1 ? withTags(3, "number")).futureValue
 
-      // delete and wait for confirmation
-      (actor1 ? DeleteCmd(1)).futureValue shouldBe "deleted-1"
+        // delete and wait for confirmation
+        (actor1 ? DeleteCmd(1)).futureValue shouldBe "deleted-1"
 
-      journalOps.withCurrentEventsByPersistenceId()("my-1") { tp =>
-        tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
-        tp.expectComplete()
+        journalOps.withCurrentEventsByPersistenceId()("my-1") { tp =>
+          tp.request(Int.MaxValue)
+          tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
+          tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
+          tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
+          tp.expectComplete()
+        }
       }
-
-    }
   }
 
-  it should "return logically deleted events when using EventsByPersistenceId (backward compatibility)" in withActorSystem { implicit system =>
-    val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors(replyToMessages = true) { (actor1, _, _) =>
-      (actor1 ? withTags(1, "number")).futureValue
-      (actor1 ? withTags(2, "number")).futureValue
-      (actor1 ? withTags(3, "number")).futureValue
+  it should "return logically deleted events when using EventsByPersistenceId (backward compatibility)" in withActorSystem {
+    implicit system =>
+      val journalOps = new ScalaJdbcReadJournalOperations(system)
+      withTestActors(replyToMessages = true) { (actor1, _, _) =>
+        (actor1 ? withTags(1, "number")).futureValue
+        (actor1 ? withTags(2, "number")).futureValue
+        (actor1 ? withTags(3, "number")).futureValue
 
-      // delete and wait for confirmation
-      (actor1 ? DeleteCmd(1)).futureValue shouldBe "deleted-1"
+        // delete and wait for confirmation
+        (actor1 ? DeleteCmd(1)).futureValue shouldBe "deleted-1"
 
-      journalOps.withEventsByPersistenceId()("my-1") { tp =>
-        tp.request(Int.MaxValue)
-        tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
-        tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
-        tp.cancel()
+        journalOps.withEventsByPersistenceId()("my-1") { tp =>
+          tp.request(Int.MaxValue)
+          tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
+          tp.expectNextPF { case EventEnvelope(Sequence(2), _, _, _) => }
+          tp.expectNextPF { case EventEnvelope(Sequence(3), _, _, _) => }
+          tp.cancel()
+        }
       }
-
-    }
   }
 }
 

--- a/src/test/scala/akka/persistence/jdbc/query/MultipleReadJournalTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/MultipleReadJournalTest.scala
@@ -22,8 +22,9 @@ import akka.persistence.query.{ NoOffset, PersistenceQuery }
 import akka.stream.{ ActorMaterializer, Materializer }
 import akka.stream.scaladsl.Sink
 
-class MultipleReadJournalTest extends QueryTestSpec("h2-two-read-journals-application.conf", configOverrides) with H2Cleaner {
-
+class MultipleReadJournalTest
+    extends QueryTestSpec("h2-two-read-journals-application.conf", configOverrides)
+    with H2Cleaner {
   it should "be able to create two read journals and use eventsByTag on them" in withActorSystem { implicit system =>
     implicit val mat: Materializer = ActorMaterializer()
     val normalReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)

--- a/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -39,16 +39,27 @@ import scala.concurrent.duration.{ FiniteDuration, _ }
 trait ReadJournalOperations {
   def withCurrentPersistenceIds(within: FiniteDuration = 60.second)(f: TestSubscriber.Probe[String] => Unit): Unit
   def withPersistenceIds(within: FiniteDuration = 60.second)(f: TestSubscriber.Probe[String] => Unit): Unit
-  def withCurrentEventsByPersistenceId(within: FiniteDuration = 60.second)(persistenceId: String, fromSequenceNr: Long = 0, toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit
-  def withEventsByPersistenceId(within: FiniteDuration = 60.second)(persistenceId: String, fromSequenceNr: Long = 0, toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit
-  def withCurrentEventsByTag(within: FiniteDuration = 60.second)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit
-  def withEventsByTag(within: FiniteDuration = 60.second)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit
+  def withCurrentEventsByPersistenceId(within: FiniteDuration = 60.second)(
+      persistenceId: String,
+      fromSequenceNr: Long = 0,
+      toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit
+  def withEventsByPersistenceId(within: FiniteDuration = 60.second)(
+      persistenceId: String,
+      fromSequenceNr: Long = 0,
+      toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit
+  def withCurrentEventsByTag(within: FiniteDuration = 60.second)(tag: String, offset: Offset)(
+      f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit
+  def withEventsByTag(within: FiniteDuration = 60.second)(tag: String, offset: Offset)(
+      f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit
   def countJournal: Future[Long]
 }
 
-class ScalaJdbcReadJournalOperations(readJournal: JdbcReadJournal)(implicit system: ActorSystem, mat: Materializer) extends ReadJournalOperations {
+class ScalaJdbcReadJournalOperations(readJournal: JdbcReadJournal)(implicit system: ActorSystem, mat: Materializer)
+    extends ReadJournalOperations {
   def this(system: ActorSystem) =
-    this(PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier))(system, ActorMaterializer()(system))
+    this(PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier))(
+      system,
+      ActorMaterializer()(system))
 
   import system.dispatcher
 
@@ -62,37 +73,58 @@ class ScalaJdbcReadJournalOperations(readJournal: JdbcReadJournal)(implicit syst
     tp.within(within)(f(tp))
   }
 
-  def withCurrentEventsByPersistenceId(within: FiniteDuration)(persistenceId: String, fromSequenceNr: Long = 0, toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
-    val tp = readJournal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).runWith(TestSink.probe[EventEnvelope])
+  def withCurrentEventsByPersistenceId(within: FiniteDuration)(
+      persistenceId: String,
+      fromSequenceNr: Long = 0,
+      toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+    val tp = readJournal
+      .currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr)
+      .runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
-  def withEventsByPersistenceId(within: FiniteDuration)(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
-    val tp = readJournal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).runWith(TestSink.probe[EventEnvelope])
+  def withEventsByPersistenceId(within: FiniteDuration)(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+    val tp = readJournal
+      .eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr)
+      .runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
-  def withCurrentEventsByTag(within: FiniteDuration)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+  def withCurrentEventsByTag(within: FiniteDuration)(tag: String, offset: Offset)(
+      f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
     val tp = readJournal.currentEventsByTag(tag, offset).runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
-  def withEventsByTag(within: FiniteDuration)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+  def withEventsByTag(within: FiniteDuration)(tag: String, offset: Offset)(
+      f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
     val tp = readJournal.eventsByTag(tag, offset).runWith(TestSink.probe[EventEnvelope])
     tp.within(within)(f(tp))
   }
 
   override def countJournal: Future[Long] =
-    readJournal.currentPersistenceIds()
+    readJournal
+      .currentPersistenceIds()
       .filter(pid => (1 to 3).map(id => s"my-$id").contains(pid))
       .mapAsync(1) { pid =>
         readJournal.currentEventsByPersistenceId(pid, 0, Long.MaxValue).map(_ => 1L).runWith(Sink.seq).map(_.sum)
-      }.runWith(Sink.seq).map(_.sum)
+      }
+      .runWith(Sink.seq)
+      .map(_.sum)
 }
 
-class JavaDslJdbcReadJournalOperations(readJournal: javadsl.JdbcReadJournal)(implicit system: ActorSystem, mat: Materializer) extends ReadJournalOperations {
+class JavaDslJdbcReadJournalOperations(readJournal: javadsl.JdbcReadJournal)(
+    implicit system: ActorSystem,
+    mat: Materializer)
+    extends ReadJournalOperations {
   def this(system: ActorSystem) =
-    this(PersistenceQuery.get(system).getReadJournalFor(classOf[javadsl.JdbcReadJournal], JavaJdbcReadJournal.Identifier))(system, ActorMaterializer()(system))
+    this(
+      PersistenceQuery.get(system).getReadJournalFor(classOf[javadsl.JdbcReadJournal], JavaJdbcReadJournal.Identifier))(
+      system,
+      ActorMaterializer()(system))
 
   import system.dispatcher
 
@@ -106,37 +138,57 @@ class JavaDslJdbcReadJournalOperations(readJournal: javadsl.JdbcReadJournal)(imp
     tp.within(within)(f(tp))
   }
 
-  def withCurrentEventsByPersistenceId(within: FiniteDuration)(persistenceId: String, fromSequenceNr: Long = 0, toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
-    val tp = readJournal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).runWith(JavaSink.probe(system), mat)
+  def withCurrentEventsByPersistenceId(within: FiniteDuration)(
+      persistenceId: String,
+      fromSequenceNr: Long = 0,
+      toSequenceNr: Long = Long.MaxValue)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+    val tp = readJournal
+      .currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr)
+      .runWith(JavaSink.probe(system), mat)
     tp.within(within)(f(tp))
   }
 
-  def withEventsByPersistenceId(within: FiniteDuration)(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
-    val tp = readJournal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).runWith(JavaSink.probe(system), mat)
+  def withEventsByPersistenceId(within: FiniteDuration)(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+    val tp = readJournal
+      .eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr)
+      .runWith(JavaSink.probe(system), mat)
     tp.within(within)(f(tp))
   }
 
-  def withCurrentEventsByTag(within: FiniteDuration)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+  def withCurrentEventsByTag(within: FiniteDuration)(tag: String, offset: Offset)(
+      f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
     val tp = readJournal.currentEventsByTag(tag, offset).runWith(JavaSink.probe(system), mat)
     tp.within(within)(f(tp))
   }
 
-  def withEventsByTag(within: FiniteDuration)(tag: String, offset: Offset)(f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
+  def withEventsByTag(within: FiniteDuration)(tag: String, offset: Offset)(
+      f: TestSubscriber.Probe[EventEnvelope] => Unit): Unit = {
     val tp = readJournal.eventsByTag(tag, offset).runWith(JavaSink.probe(system), mat)
     tp.within(within)(f(tp))
   }
 
   override def countJournal: Future[Long] =
-    readJournal.currentPersistenceIds().asScala
+    readJournal
+      .currentPersistenceIds()
+      .asScala
       .filter(pid => (1 to 3).map(id => s"my-$id").contains(pid))
       .mapAsync(1) { pid =>
-        readJournal.currentEventsByPersistenceId(pid, 0, Long.MaxValue).asScala.map(_ => 1L).runFold(List.empty[Long])(_ :+ _).map(_.sum)
-      }.runFold(List.empty[Long])(_ :+ _)
+        readJournal
+          .currentEventsByPersistenceId(pid, 0, Long.MaxValue)
+          .asScala
+          .map(_ => 1L)
+          .runFold(List.empty[Long])(_ :+ _)
+          .map(_.sum)
+      }
+      .runFold(List.empty[Long])(_ :+ _)
       .map(_.sum)
 }
 
-abstract class QueryTestSpec(config: String, configOverrides: Map[String, ConfigValue] = Map.empty) extends SingleActorSystemPerTestSpec(config, configOverrides) {
-
+abstract class QueryTestSpec(config: String, configOverrides: Map[String, ConfigValue] = Map.empty)
+    extends SingleActorSystemPerTestSpec(config, configOverrides) {
   case class DeleteCmd(toSequenceNr: Long = Long.MaxValue) extends Serializable
 
   final val ExpectNextTimeout = 10.second
@@ -155,7 +207,7 @@ abstract class QueryTestSpec(config: String, configOverrides: Map[String, Config
       case DeleteCmd(toSequenceNr) =>
         deleteMessages(toSequenceNr)
         if (replyToMessages) {
-          context become awaitingDeleting(sender())
+          context.become(awaitingDeleting(sender()))
         }
 
       case event: Int =>
@@ -185,16 +237,15 @@ abstract class QueryTestSpec(config: String, configOverrides: Map[String, Config
     }
 
     def awaitingDeleting(origSender: ActorRef): Receive = LoggingReceive {
-
       case DeleteMessagesSuccess(toSequenceNr) =>
         origSender ! s"deleted-$toSequenceNr"
         unstashAll()
-        context become idle
+        context.become(idle)
 
       case DeleteMessagesFailure(ex, _) =>
         origSender ! Status.Failure(ex)
         unstashAll()
-        context become idle
+        context.become(idle)
 
       // stash whatever other messages
       case _ => stash()
@@ -213,14 +264,18 @@ abstract class QueryTestSpec(config: String, configOverrides: Map[String, Config
     system.actorOf(Props(new TestActor(persistenceId, replyToMessages)))
   }
 
-  def withTestActors(seq: Int = 1, replyToMessages: Boolean = false)(f: (ActorRef, ActorRef, ActorRef) => Unit)(implicit system: ActorSystem): Unit = {
+  def withTestActors(seq: Int = 1, replyToMessages: Boolean = false)(f: (ActorRef, ActorRef, ActorRef) => Unit)(
+      implicit system: ActorSystem): Unit = {
     val refs = (seq until seq + 3).map(setupEmpty(_, replyToMessages)).toList
-    try f(refs.head, refs.drop(1).head, refs.drop(2).head) finally killActors(refs: _*)
+    try f(refs.head, refs.drop(1).head, refs.drop(2).head)
+    finally killActors(refs: _*)
   }
 
-  def withManyTestActors(amount: Int, seq: Int = 1, replyToMessages: Boolean = false)(f: Seq[ActorRef] => Unit)(implicit system: ActorSystem): Unit = {
+  def withManyTestActors(amount: Int, seq: Int = 1, replyToMessages: Boolean = false)(f: Seq[ActorRef] => Unit)(
+      implicit system: ActorSystem): Unit = {
     val refs = (seq until seq + amount).map(setupEmpty(_, replyToMessages)).toList
-    try f(refs) finally killActors(refs: _*)
+    try f(refs)
+    finally killActors(refs: _*)
   }
 
   def withTags(payload: Any, tags: String*) = Tagged(payload, Set(tags: _*))
@@ -230,9 +285,7 @@ trait PostgresCleaner extends QueryTestSpec {
   import akka.persistence.jdbc.util.Schema.Postgres
 
   val actionsClearPostgres =
-    DBIO.seq(
-      sqlu"""TRUNCATE journal""",
-      sqlu"""TRUNCATE snapshot""").transactionally
+    DBIO.seq(sqlu"""TRUNCATE journal""", sqlu"""TRUNCATE snapshot""").transactionally
 
   def clearPostgres(): Unit =
     withDatabase(_.run(actionsClearPostgres).futureValue)
@@ -252,9 +305,7 @@ trait MysqlCleaner extends QueryTestSpec {
   import akka.persistence.jdbc.util.Schema.MySQL
 
   val actionsClearMySQL =
-    DBIO.seq(
-      sqlu"""TRUNCATE journal""",
-      sqlu"""TRUNCATE snapshot""").transactionally
+    DBIO.seq(sqlu"""TRUNCATE journal""", sqlu"""TRUNCATE snapshot""").transactionally
 
   def clearMySQL(): Unit =
     withDatabase(_.run(actionsClearMySQL).futureValue)
@@ -274,10 +325,9 @@ trait OracleCleaner extends QueryTestSpec {
   import akka.persistence.jdbc.util.Schema.Oracle
 
   val actionsClearOracle =
-    DBIO.seq(
-      sqlu"""DELETE FROM "journal"""",
-      sqlu"""DELETE FROM "snapshot"""",
-      sqlu"""BEGIN "reset_sequence"; END; """).transactionally
+    DBIO
+      .seq(sqlu"""DELETE FROM "journal"""", sqlu"""DELETE FROM "snapshot"""", sqlu"""BEGIN "reset_sequence"; END; """)
+      .transactionally
 
   def clearOracle(): Unit =
     withDatabase(_.run(actionsClearOracle).futureValue)
@@ -297,10 +347,12 @@ trait SqlServerCleaner extends QueryTestSpec {
   import akka.persistence.jdbc.util.Schema.SqlServer
 
   val actionsClearSqlServer =
-    DBIO.seq(
-      sqlu"""TRUNCATE TABLE journal""",
-      sqlu"""TRUNCATE TABLE snapshot""",
-      sqlu"""DBCC CHECKIDENT('journal', RESEED, 1)""").transactionally
+    DBIO
+      .seq(
+        sqlu"""TRUNCATE TABLE journal""",
+        sqlu"""TRUNCATE TABLE snapshot""",
+        sqlu"""DBCC CHECKIDENT('journal', RESEED, 1)""")
+      .transactionally
 
   def clearSqlServer(): Unit =
     withDatabase(_.run(actionsClearSqlServer).futureValue)
@@ -325,9 +377,7 @@ trait H2Cleaner extends QueryTestSpec {
   import akka.persistence.jdbc.util.Schema.H2
 
   val actionsClearH2 =
-    DBIO.seq(
-      sqlu"""TRUNCATE TABLE journal""",
-      sqlu"""TRUNCATE TABLE snapshot""").transactionally
+    DBIO.seq(sqlu"""TRUNCATE TABLE journal""", sqlu"""TRUNCATE TABLE snapshot""").transactionally
 
   def clearH2(): Unit =
     withDatabase(_.run(actionsClearH2).futureValue)

--- a/src/test/scala/akka/persistence/jdbc/query/dao/ReadJournalTablesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/dao/ReadJournalTablesTest.scala
@@ -21,7 +21,6 @@ import akka.persistence.jdbc.journal.dao.JournalTables
 import slick.jdbc.JdbcProfile
 
 class ReadJournalTablesTest extends TablesTestSpec {
-
   val readJournalTableConfiguration = readJournalConfig.journalTableConfiguration
 
   object TestByteAReadJournalTables extends JournalTables {
@@ -39,8 +38,10 @@ class ReadJournalTablesTest extends TablesTestSpec {
 
   it should "be configured with column names" in {
     val colName = toColumnName(readJournalTableConfiguration.tableName)(_)
-    TestByteAReadJournalTables.JournalTable.baseTableRow.persistenceId.toString shouldBe colName(readJournalTableConfiguration.columnNames.persistenceId)
-    TestByteAReadJournalTables.JournalTable.baseTableRow.sequenceNumber.toString shouldBe colName(readJournalTableConfiguration.columnNames.sequenceNumber)
+    TestByteAReadJournalTables.JournalTable.baseTableRow.persistenceId.toString shouldBe colName(
+      readJournalTableConfiguration.columnNames.persistenceId)
+    TestByteAReadJournalTables.JournalTable.baseTableRow.sequenceNumber.toString shouldBe colName(
+      readJournalTableConfiguration.columnNames.sequenceNumber)
     //    TestByteAJournalTables.JournalTable.baseTableRow.tags.toString() shouldBe colName(journalTableConfiguration.columnNames.tags)
   }
 }

--- a/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
+++ b/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
@@ -2,7 +2,7 @@ package akka.persistence.jdbc.query.dao
 
 import akka.NotUsed
 import akka.persistence.jdbc.query.dao.TestProbeReadJournalDao.JournalSequence
-import akka.persistence.{ PersistentRepr, jdbc }
+import akka.persistence.{ jdbc, PersistentRepr }
 import akka.stream.scaladsl.Source
 import akka.testkit.TestProbe
 import akka.util.Timeout
@@ -32,12 +32,20 @@ class TestProbeReadJournalDao(val probe: TestProbe) extends ReadJournalDao {
    * Returns a Source of bytes for certain tag from an offset. The result is sorted by
    * created time asc thus the offset is relative to the creation time
    */
-  override def eventsByTag(tag: String, offset: Long, maxOffset: Long, max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] = ???
+  override def eventsByTag(
+      tag: String,
+      offset: Long,
+      maxOffset: Long,
+      max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] = ???
 
   /**
    * Returns a Source of bytes for a certain persistenceId
    */
-  override def messages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long): Source[Try[PersistentRepr], NotUsed] = ???
+  override def messages(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      max: Long): Source[Try[PersistentRepr], NotUsed] = ???
 
   /**
    * @param offset Minimum value to retrieve

--- a/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
@@ -25,20 +25,26 @@ import akka.testkit.TestProbe
 
 import scala.concurrent.duration._
 
-abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: SchemaType) extends SharedActorSystemTestSpec(config) {
-
+abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: SchemaType)
+    extends SharedActorSystemTestSpec(config) {
   case class PersistFailure(cause: Throwable, event: Any, seqNr: Long)
   case class PersistRejected(cause: Throwable, event: Any, seqNr: Long)
 
-  class TestActor(val persistenceId: String, recoverProbe: ActorRef, persistFailureProbe: ActorRef, persistRejectedProbe: ActorRef) extends PersistentActor {
+  class TestActor(
+      val persistenceId: String,
+      recoverProbe: ActorRef,
+      persistFailureProbe: ActorRef,
+      persistRejectedProbe: ActorRef)
+      extends PersistentActor {
     override val receiveRecover: Receive = LoggingReceive {
       case msg => recoverProbe ! msg
     }
 
     override val receiveCommand: Receive = LoggingReceive {
-      case msg => persist(msg) { _ =>
-        sender ! akka.actor.Status.Success("")
-      }
+      case msg =>
+        persist(msg) { _ =>
+          sender ! akka.actor.Status.Success("")
+        }
     }
 
     override protected def onPersistFailure(cause: Throwable, event: Any, seqNr: Long): Unit =
@@ -52,8 +58,10 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
     val recoverProbe = TestProbe()
     val persistFailureProbe = TestProbe()
     val persistRejectedProbe = TestProbe()
-    val persistentActor = system.actorOf(Props(new TestActor(s"my-$id", recoverProbe.ref, persistFailureProbe.ref, persistRejectedProbe.ref)))
-    try f(persistentActor)(recoverProbe)(persistFailureProbe)(persistRejectedProbe) finally killActors(persistentActor)
+    val persistentActor = system.actorOf(
+      Props(new TestActor(s"my-$id", recoverProbe.ref, persistFailureProbe.ref, persistRejectedProbe.ref)))
+    try f(persistentActor)(recoverProbe)(persistFailureProbe)(persistRejectedProbe)
+    finally killActors(persistentActor)
   }
 
   override def beforeAll(): Unit = {
@@ -126,12 +134,16 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
   }
 }
 
-class PostgresStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("postgres-application.conf", Postgres())
+class PostgresStoreOnlySerializableMessagesTest
+    extends StoreOnlySerializableMessagesTest("postgres-application.conf", Postgres())
 
-class MySQLStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("mysql-application.conf", MySQL())
+class MySQLStoreOnlySerializableMessagesTest
+    extends StoreOnlySerializableMessagesTest("mysql-application.conf", MySQL())
 
-class OracleStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("oracle-application.conf", Oracle())
+class OracleStoreOnlySerializableMessagesTest
+    extends StoreOnlySerializableMessagesTest("oracle-application.conf", Oracle())
 
-class SqlServerStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("sqlserver-application.conf", SqlServer())
+class SqlServerStoreOnlySerializableMessagesTest
+    extends StoreOnlySerializableMessagesTest("sqlserver-application.conf", SqlServer())
 
 class H2StoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("h2-application.conf", H2())

--- a/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
@@ -26,8 +26,12 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.duration._
 
-abstract class JdbcSnapshotStoreSpec(config: Config, schemaType: SchemaType) extends SnapshotStoreSpec(config) with BeforeAndAfterAll with ScalaFutures with ClasspathResources with DropCreate {
-
+abstract class JdbcSnapshotStoreSpec(config: Config, schemaType: SchemaType)
+    extends SnapshotStoreSpec(config)
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with ClasspathResources
+    with DropCreate {
   implicit val pc: PatienceConfig = PatienceConfig(timeout = 10.seconds)
 
   implicit lazy val ec = system.dispatcher
@@ -48,12 +52,14 @@ abstract class JdbcSnapshotStoreSpec(config: Config, schemaType: SchemaType) ext
   }
 }
 
-class PostgresSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("postgres-application.conf"), Postgres())
+class PostgresSnapshotStoreSpec
+    extends JdbcSnapshotStoreSpec(ConfigFactory.load("postgres-application.conf"), Postgres())
 
 class MySQLSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("mysql-application.conf"), MySQL())
 
 class OracleSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("oracle-application.conf"), Oracle())
 
-class SqlServerSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("sqlserver-application.conf"), SqlServer())
+class SqlServerSnapshotStoreSpec
+    extends JdbcSnapshotStoreSpec(ConfigFactory.load("sqlserver-application.conf"), SqlServer())
 
 class H2SnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("h2-application.conf"), H2())

--- a/src/test/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTablesTest.scala
+++ b/src/test/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTablesTest.scala
@@ -36,9 +36,13 @@ class SnapshotTablesTest extends TablesTestSpec {
 
   it should "be configured with column names" in {
     val colName = toColumnName(snapshotTableConfiguration.tableName)(_)
-    TestByteASnapshotTables.SnapshotTable.baseTableRow.persistenceId.toString shouldBe colName(snapshotTableConfiguration.columnNames.persistenceId)
-    TestByteASnapshotTables.SnapshotTable.baseTableRow.sequenceNumber.toString shouldBe colName(snapshotTableConfiguration.columnNames.sequenceNumber)
-    TestByteASnapshotTables.SnapshotTable.baseTableRow.created.toString shouldBe colName(snapshotTableConfiguration.columnNames.created)
-    TestByteASnapshotTables.SnapshotTable.baseTableRow.snapshot.toString shouldBe colName(snapshotTableConfiguration.columnNames.snapshot)
+    TestByteASnapshotTables.SnapshotTable.baseTableRow.persistenceId.toString shouldBe colName(
+      snapshotTableConfiguration.columnNames.persistenceId)
+    TestByteASnapshotTables.SnapshotTable.baseTableRow.sequenceNumber.toString shouldBe colName(
+      snapshotTableConfiguration.columnNames.sequenceNumber)
+    TestByteASnapshotTables.SnapshotTable.baseTableRow.created.toString shouldBe colName(
+      snapshotTableConfiguration.columnNames.created)
+    TestByteASnapshotTables.SnapshotTable.baseTableRow.snapshot.toString shouldBe colName(
+      snapshotTableConfiguration.columnNames.snapshot)
   }
 }

--- a/src/test/scala/akka/persistence/jdbc/util/ClasspathResources.scala
+++ b/src/test/scala/akka/persistence/jdbc/util/ClasspathResources.scala
@@ -23,7 +23,6 @@ import scala.io.{ Source => ScalaIOSource }
 object ClasspathResources extends ClasspathResources
 
 trait ClasspathResources {
-
   def streamToString(is: InputStream): String =
     ScalaIOSource.fromInputStream(is).mkString
 
@@ -32,5 +31,4 @@ trait ClasspathResources {
 
   def fromClasspathAsStream(fileName: String): InputStream =
     getClass.getClassLoader.getResourceAsStream(fileName)
-
 }


### PR DESCRIPTION
## Purpose

This removes Scalaliform in favor of scalafmt. It is using a copy of Akka's `.scalafmt.conf` to maintain consistency with other projects in Akka org.

There are multiple commits to make it easier to review.

## Changes

- [x] bye, scalariform
- [x] hello, scalafmt