### PR TITLE
Scala 2.12.10, 2.13.1; Only install the used JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ before_install:
   - git remote set-branches --add origin master && git fetch --unshallow
   # using jabba for custom jdk management
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
-  - jabba install ${JDK:=adopt@~1.8-0}
 
 # default script for jobs, that do not have any specified
 script:
+  - jabba install ${JDK:=adopt@~1.8-0}
   - jabba use ${JDK:=adopt@~1.8-0}
   - java -version
   - ${PRE_CMD:=return 0} # do nothing if not set

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ before_install:
   - git remote set-branches --add origin master && git fetch --unshallow
   # using jabba for custom jdk management
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
-  - jabba install adopt@~1.8-0
-  - jabba install adopt@~1.11-0
+  - jabba install ${JDK:=adopt@~1.8-0}
 
 # default script for jobs, that do not have any specified
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
     - stage: test
       env:
         - PRE_CMD="./scripts/launch-all.sh"
-        - CMD="++2.12.8 test"
+        - CMD="++2.12.10 test"
       name: "Run tests with Scala 2.12 and AdoptOpenJDK 8"
     - env:
         - PRE_CMD="./scripts/launch-all.sh"
@@ -36,7 +36,7 @@ jobs:
         - JDK="adopt@~1.11-0"
         - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
         - PRE_CMD="./scripts/launch-all.sh"
-        - CMD="++2.12.8 test"
+        - CMD="++2.12.10 test"
       name: "Run tests with Scala 2.12 and AdoptOpenJDK 11"
     - env:
         - JDK="adopt@~1.11-0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
 
   val Scala212 = "2.12.10"
-  val Scala213 = "2.13.0"
+  val Scala213 = "2.13.1"
   val ScalaVersions = Seq(Scala212, Scala213)
 
   val AkkaVersion = if (Nightly) "2.6.0" else "2.5.25"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ object Dependencies {
 
   val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
 
+  // Keep in sync with .travis.yml
   val Scala212 = "2.12.10"
   val Scala213 = "2.13.1"
   val ScalaVersions = Seq(Scala212, Scala213)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
 
-  val Scala212 = "2.12.8"
+  val Scala212 = "2.12.10"
   val Scala213 = "2.13.0"
   val ScalaVersions = Seq(Scala212, Scala213)
 


### PR DESCRIPTION
## Purpose

Avoid installing a version of the JDK that won't be used by the job.

## Changes

- [x] only install the JDK used by the job
- [x] opportunistically update Scala to version 2.12.10
- [x] opportunistically align Scala 2.13 version used by the build and Travis
