### PR TITLE
Add scala-steward config to disable PR updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -7,7 +7,5 @@ updates.ignore = [
   { groupId = "com.typesafe.akka", artifactId = "akka-slf4j" },
   { groupId = "com.typesafe.akka", artifactId = "akka-persistence-tck" },
   { groupId = "com.typesafe.akka", artifactId = "akka-stream-testkit" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-testkit" },
-  // inherited from Akka
-  { groupId = "com.typesafe", artifactId = "config" }
+  { groupId = "com.typesafe.akka", artifactId = "akka-testkit" }
 ]

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,11 +1,13 @@
 updates.ignore = [
   // explicit updates
   { groupId = "com.typesafe.akka", artifactId = "akka-actor" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-persistence:2.5.25" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-persistence-query:2.5.25" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-stream:2.5.25" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-persistence" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-persistence-query" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-stream" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-slf4j" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-persistence-tck" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-stream-testkit" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-testkit" },
   // inherited from Akka
   { groupId = "com.typesafe", artifactId = "config" }
 ]
-
-updatePullRequests = false

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updatePullRequests = false 

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,11 @@
-updatePullRequests = false 
+updates.ignore = [
+  // explicit updates
+  { groupId = "com.typesafe.akka", artifactId = "akka-actor" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-persistence:2.5.25" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-persistence-query:2.5.25" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-stream:2.5.25" },
+  // inherited from Akka
+  { groupId = "com.typesafe", artifactId = "config" }
+]
+
+updatePullRequests = false


### PR DESCRIPTION
## Purpose

This avoids scala-steward updating every pull request when something else is merged, and then clog Travis build queue.

## References

Useless until https://github.com/scala-steward-org/repos/pull/101 is merged.