### PR TITLE
Explicitly allow Java serailisation

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+// Required until https://github.com/akka/akka/pull/28333 is available
+akka.actor.allow-java-serialization = on
+
 akka-persistence-jdbc {
 
   # If set to true event deletion is performed as a soft, logical delete. Events are kept in the journal and are sill

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// Required until https://github.com/akka/akka/pull/28333 is available
-akka.actor.allow-java-serialization = on
-
 akka-persistence-jdbc {
 
   # If set to true event deletion is performed as a soft, logical delete. Events are kept in the journal and are sill

--- a/core/src/test/resources/general.conf
+++ b/core/src/test/resources/general.conf
@@ -25,6 +25,8 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
   actor {
+    // Required until https://github.com/akka/akka/pull/28333 is available
+    allow-java-serialization = on
     debug {
       receive = on // log all messages sent to an actor if that actors receive method is a LoggingReceive
       autoreceive = off // log all special messages like Kill, PoisoffPill etc sent to all actors


### PR DESCRIPTION
## Purpose

Allow Java serialization which is disallowed by default in Akka 2.6.

## References

#300 
