### PR TITLE
Filter tags on the fly - workaround for #168

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -25,6 +25,11 @@ akka-persistence-jdbc {
   #
   logicalDeletion.enable = true
 
+
+  # The tag separator to use when tagging events with more than one tag.
+  # This property affects jdbc-journal.tagSeparator and jdbc-read-journal.tagSeparator.
+  tagSeparator = ","
+
   database-provider-fqcn = "akka.persistence.jdbc.util.DefaultSlickDatabaseProvider"
 
   shared-databases {
@@ -123,7 +128,10 @@ jdbc-journal {
     }
   }
 
-  tagSeparator = ","
+  # The tag separator to use when tagging events with more than one tag.
+  # should not be configured directly, but through property akka-persistence-jdbc.tagSeparator
+  # in order to keep consistent behavior over write/read sides
+  tagSeparator = ${akka-persistence-jdbc.tagSeparator}
 
   dao = "akka.persistence.jdbc.journal.dao.ByteArrayJournalDao"
 
@@ -390,7 +398,10 @@ jdbc-read-journal {
     }
   }
 
-  tagSeparator = ","
+  # The tag separator to use when tagging events with more than one tag.
+  # should not be configured directly, but through property akka-persistence-jdbc.tagSeparator
+  # in order to keep consistent behavior over write/read sides
+  tagSeparator = ${akka-persistence-jdbc.tagSeparator}
 
   slick {
 

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -119,6 +119,42 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
     }
   }
 
+  it should "select events by tag with exact match" in withActorSystem { implicit system =>
+    val journalOps = new ScalaJdbcReadJournalOperations(system)
+
+    withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
+      (actor1 ? withTags(1, "number", "sharded-1")).futureValue
+      (actor2 ? withTags(2, "number", "sharded-10")).futureValue
+      (actor3 ? withTags(3, "number", "sharded-100")).futureValue
+
+      journalOps.withEventsByTag()("number", Sequence(Long.MinValue)) { tp =>
+        tp.request(Int.MaxValue)
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.cancel()
+      }
+
+      journalOps.withEventsByTag()("sharded-1", Sequence(Long.MinValue)) { tp =>
+        tp.request(Int.MaxValue)
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
+        tp.cancel()
+      }
+
+      journalOps.withEventsByTag()("sharded-10", Sequence(Long.MinValue)) { tp =>
+        tp.request(Int.MaxValue)
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
+        tp.cancel()
+      }
+
+      journalOps.withEventsByTag()("sharded-100", Sequence(Long.MinValue)) { tp =>
+        tp.request(Int.MaxValue)
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.cancel()
+      }
+    }
+  }
+
   it should "find all events by tag even when lots of events are persisted concurrently" in withActorSystem {
     implicit system =>
       val journalOps = new ScalaJdbcReadJournalOperations(system)

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -138,18 +138,21 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
       journalOps.withEventsByTag()("sharded-1", Sequence(Long.MinValue)) { tp =>
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("sharded-10", Sequence(Long.MinValue)) { tp =>
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("sharded-100", Sequence(Long.MinValue)) { tp =>
         tp.request(Int.MaxValue)
         tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
     }


### PR DESCRIPTION
As discussed here: https://github.com/akka/akka-persistence-jdbc/issues/318

We plan to cut a release for users that can't immediately migrate to the upcoming 4.0.0 (because of schema migrations). 

This is a quick fix for the most annoying bug we have. When using sharded tags (like in Lagom), the `eventsByTag` call may return events with unrelated tags. For instance, if you search for the tag "foo1", you also get events tag "foo10". 

The workaround is to filter out any partial match, in memory. Once merged and release, this can immediately benefit existing Lagom users. 

