### PR TITLE
Set statement parameters to improve memory usage in message query

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -144,8 +144,8 @@ jdbc-journal {
   # The maximum number of batch-inserts that may be running concurrently
   parallelism = 8
 
-  # The maximum number of elements to fetch when reading messages for specific persistenceId.
-  fetchSize = 1000
+  # The maximum number of elements to fetch when reading messages for a specific persistenceId.
+  fetch-size = 1000
 
   # Only mark as deleted. If false, delete physically
   # should not be configured directly, but through property akka-persistence-jdbc.logicalDelete.enable

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -144,6 +144,9 @@ jdbc-journal {
   # The maximum number of batch-inserts that may be running concurrently
   parallelism = 8
 
+  # The maximum number of elements to fetch when reading messages for specific persistenceId.
+  fetchSize = 1000
+
   # Only mark as deleted. If false, delete physically
   # should not be configured directly, but through property akka-persistence-jdbc.logicalDelete.enable
   # in order to keep consistent behavior over write/read sides

--- a/core/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
@@ -68,6 +68,7 @@ class BaseByteArrayJournalDaoConfig(config: Config) {
   val batchSize: Int = config.asInt("batchSize", 400)
   val parallelism: Int = config.asInt("parallelism", 8)
   val logicalDelete: Boolean = config.asBoolean("logicalDelete", default = true)
+  val fetchSize: Int = config.asInt("fetch-size", 1000)
   override def toString: String = s"BaseByteArrayJournalDaoConfig($bufferSize,$batchSize,$parallelism,$logicalDelete)"
 }
 

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
@@ -33,7 +33,7 @@ trait BaseByteArrayJournalDao extends JournalDaoWithUpdates {
   implicit val ec: ExecutionContext
   implicit val mat: Materializer
 
-  import journalConfig.daoConfig.{ batchSize, bufferSize, logicalDelete, parallelism, fetchSize }
+  import journalConfig.daoConfig.{ batchSize, bufferSize, fetchSize, logicalDelete, parallelism }
   import profile.api._
 
   val logger = LoggerFactory.getLogger(this.getClass)

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalDao.scala
@@ -33,7 +33,7 @@ trait BaseByteArrayJournalDao extends JournalDaoWithUpdates {
   implicit val ec: ExecutionContext
   implicit val mat: Materializer
 
-  import journalConfig.daoConfig.{ batchSize, bufferSize, logicalDelete, parallelism }
+  import journalConfig.daoConfig.{ batchSize, bufferSize, logicalDelete, parallelism, fetchSize }
   import profile.api._
 
   val logger = LoggerFactory.getLogger(this.getClass)
@@ -153,7 +153,7 @@ trait BaseByteArrayJournalDao extends JournalDaoWithUpdates {
             .withStatementParameters(
               rsType = ResultSetType.ForwardOnly,
               rsConcurrency = ResultSetConcurrency.ReadOnly,
-              fetchSize = 1000)
+              fetchSize = fetchSize)
             .transactionally))
       .via(serializer.deserializeFlowWithoutTags)
 }

--- a/core/src/test/scala/akka/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.query
+
+import java.util.UUID
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.persistence.{ AtomicWrite, PersistentRepr }
+import akka.persistence.jdbc.journal.dao.{ ByteArrayJournalDao, JournalTables }
+import akka.serialization.SerializationExtension
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.slf4j.LoggerFactory
+
+import scala.collection.immutable
+import scala.concurrent.{ Await, ExecutionContextExecutor, Future }
+import scala.concurrent.duration._
+import scala.util.{ Failure, Random, Success }
+
+object JournalDaoStreamMessagesMemoryTest {
+
+  val configOverrides: Map[String, ConfigValue] = Map("jdbc-journal.fetch-size" -> ConfigValueFactory.fromAnyRef("100"))
+}
+
+abstract class JournalDaoStreamMessagesMemoryTest(configFile: String)
+    extends QueryTestSpec(configFile, JournalDaoStreamMessagesMemoryTest.configOverrides)
+    with JournalTables {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  val journalSequenceActorConfig = readJournalConfig.journalSequenceRetrievalConfiguration
+  val journalTableCfg = journalConfig.journalTableConfiguration
+
+  import profile.api._
+
+  implicit val askTimeout = 50.millis
+
+  def generateId: Int = 0
+
+  behavior.of("Replaying Persistence Actor")
+
+  it should "stream events" in {
+    withActorSystem { implicit system: ActorSystem =>
+      withDatabase { db =>
+        implicit val mat: ActorMaterializer = ActorMaterializer()
+        implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+        val persistenceId = UUID.randomUUID().toString
+        val dao = new ByteArrayJournalDao(db, profile, journalConfig, SerializationExtension(system))
+
+        val maxMem = Runtime.getRuntime.maxMemory()
+
+        // We don't want it to be too large otherwise the tests take too long to setup
+        // we also must be able to call .toInt on maxMen (see below) and we need it to stay inside the Int boundaries
+        // Moreover, the Oracle docker is limited to the size of the file on disk and we can't push too much data on it
+        // (128M seems to work for the Oracle Docker)
+        val memoryLimit = 128000000
+        if (maxMem > memoryLimit)
+          throw new RuntimeException(
+            s"This test can only be run with a limited amount of memory ($memoryLimit), found [$maxMem]")
+
+        val payloadSize = 5000 // 5000 bytes
+        val eventsPerBatch = 1000
+
+        val numberOfInsertBatches = {
+          // calculate the number of batches using a factor to make sure we go a little bit over the limit
+          (maxMem.toInt / (payloadSize * eventsPerBatch) * 1.2).round.toInt
+        }
+        val totalMessages = numberOfInsertBatches * eventsPerBatch
+        val totalMessagePayload = totalMessages * payloadSize
+        log.info(
+          s"maxMem: $maxMem, batches: $numberOfInsertBatches (with $eventsPerBatch events), total messages: $totalMessages, total msgs size: $totalMessagePayload")
+
+        // payload can be the same when inserting to avoid unnecessary memory usage
+        val payload = Array.fill(payloadSize)('a'.toByte)
+
+        val lastInsert =
+          Source
+            .fromIterator(() => (1 to numberOfInsertBatches).toIterator)
+            .mapAsync(1) { i =>
+              val end = i * eventsPerBatch
+              val start = end - (eventsPerBatch - 1)
+              log.info(s"batch $i - events from $start to $end")
+              val atomicWrites =
+                (start to end).map { j =>
+                  AtomicWrite(immutable.Seq(PersistentRepr(payload, j, persistenceId)))
+                }.toSeq
+
+              dao.asyncWriteMessages(atomicWrites).map(_ => i)
+            }
+            .runWith(Sink.last)
+
+        // wait until we write all messages
+        // being very generous, 1 second per message
+        lastInsert.futureValue(Timeout(totalMessages.seconds))
+
+        val messagesSrc = dao.messages(persistenceId, 0, totalMessages, totalMessages)
+        val doneFut =
+          messagesSrc.runForeach {
+            case Success(repr) =>
+              log.info(s"fetched: ${repr.persistenceId} - ${repr.sequenceNr}/${totalMessages}")
+            case Failure(exception) => println(exception)
+          }
+
+        // wait until we read all messages
+        // being very generous, 1 second per message
+        doneFut.futureValue(Timeout(totalMessages.seconds))
+      }
+    }
+  }
+}
+
+class PostgresJournalDaoStreamMessagesMemoryTest
+    extends JournalDaoStreamMessagesMemoryTest("postgres-application.conf")
+    with PostgresCleaner
+
+// TODO: MySQL not working with withStatementParameters
+//class MySQLJournalDaoStreamMessagesMemoryTest
+//  extends ReplayPersistenceActorMemoryTest("mysql-application.conf")
+//    with MysqlCleaner
+
+class OracleJournalDaoStreamMessagesMemoryTest
+    extends JournalDaoStreamMessagesMemoryTest("oracle-application.conf")
+    with OracleCleaner
+
+class SqlServerJournalDaoStreamMessagesMemoryTest
+    extends JournalDaoStreamMessagesMemoryTest("sqlserver-application.conf")
+    with SqlServerCleaner

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -35,6 +35,7 @@ object ProjectAutoPlugin extends AutoPlugin {
     crossScalaVersions := Dependencies.ScalaVersions,
     scalaVersion := Dependencies.Scala212,
     Test / fork := true,
+    Test / javaOptions ++= Seq("-Xms64m", "-Xmx128m"),
     Test / parallelExecution := false,
     Test / logBuffered := true,
     scalacOptions ++= Seq(


### PR DESCRIPTION
This is a possible fix for #322
According to https://scala-slick.org/doc/3.3.2/dbio.html#streaming these parameters are needed for postgres to ensure that not all data is retrieved at once (by the jdbc driver) when executing a query.


Todos (help wanted)
- [x] Make the fetch size configurable 
- [ ] Create a test where we can configure the number of events we store, in which we can reproduce the memory issue as described in #322. See if this fix actually improves the situaties
