### PR TITLE
read events in batches from asyncReplayMessages, #322

### DIFF
--- a/core/src/main/mima-filters/3.5.3.backwards.excludes/issue-322-messagesWithBatch.excludes
+++ b/core/src/main/mima-filters/3.5.3.backwards.excludes/issue-322-messagesWithBatch.excludes
@@ -1,0 +1,9 @@
+# #322 Adding messagesWithBatch to Dao traits
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.persistence.jdbc.journal.dao.JournalDao.messagesWithBatch")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.persistence.jdbc.journal.dao.H2JournalDao.messagesWithBatch")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.persistence.jdbc.journal.dao.JournalDaoWithUpdates.messagesWithBatch")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.persistence.jdbc.query.dao.BaseByteArrayReadJournalDao.ec")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.persistence.jdbc.query.dao.BaseByteArrayReadJournalDao.mat")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.persistence.jdbc.query.dao.H2ReadJournalDao.messagesWithBatch")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.persistence.jdbc.query.dao.OracleReadJournalDao.messagesWithBatch")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.persistence.jdbc.query.dao.ReadJournalDao.messagesWithBatch")

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -141,6 +141,8 @@ jdbc-journal {
   bufferSize = 1000
   # The maximum size of the batches in which journal rows will be inserted
   batchSize = 400
+  # The maximum size of the batches in which journal rows will be read when recovering
+  replayBatchSize = 400
   # The maximum number of batch-inserts that may be running concurrently
   parallelism = 8
 

--- a/core/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/config/AkkaPersistenceConfig.scala
@@ -66,6 +66,7 @@ class JournalPluginConfig(config: Config) {
 class BaseByteArrayJournalDaoConfig(config: Config) {
   val bufferSize: Int = config.asInt("bufferSize", 1000)
   val batchSize: Int = config.asInt("batchSize", 400)
+  val replayBatchSize: Int = config.asInt("replayBatchSize", 400)
   val parallelism: Int = config.asInt("parallelism", 8)
   val logicalDelete: Boolean = config.asBoolean("logicalDelete", default = true)
   override def toString: String = s"BaseByteArrayJournalDaoConfig($bufferSize,$batchSize,$parallelism,$logicalDelete)"

--- a/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -109,7 +109,8 @@ class JdbcAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
   override def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(
       recoveryCallback: (PersistentRepr) => Unit): Future[Unit] =
     journalDao
-      .messages(persistenceId, fromSequenceNr, toSequenceNr, max)
+      .messagesWithBatch(persistenceId, fromSequenceNr, toSequenceNr, journalConfig.daoConfig.replayBatchSize, None)
+      .take(max)
       .mapAsync(1)(deserializedRepr => Future.fromTry(deserializedRepr))
       .runForeach(recoveryCallback)
       .map(_ => ())

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDao.scala
@@ -5,15 +5,12 @@
 
 package akka.persistence.jdbc.journal.dao
 
-import akka.NotUsed
-import akka.persistence.{ AtomicWrite, PersistentRepr }
-import akka.stream.scaladsl._
-
+import akka.persistence.AtomicWrite
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.util.Try
 
-trait JournalDao {
+trait JournalDao extends JournalDaoWithReadMessages {
 
   /**
    * Deletes all persistent messages up to toSequenceNr (inclusive) for the persistenceId
@@ -25,15 +22,6 @@ trait JournalDao {
    * found for the `persistenceId`, 0L will be the highest sequence number
    */
   def highestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long]
-
-  /**
-   * Returns a Source of PersistentRepr for a certain persistenceId
-   */
-  def messages(
-      persistenceId: String,
-      fromSequenceNr: Long,
-      toSequenceNr: Long,
-      max: Long): Source[Try[PersistentRepr], NotUsed]
 
   /**
    * @see [[akka.persistence.journal.AsyncWriteJournal.asyncWriteMessages(messages)]]

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDaoWithReadMessages.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDaoWithReadMessages.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.journal.dao
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+import akka.NotUsed
+import akka.actor.Scheduler
+import akka.persistence.PersistentRepr
+import akka.stream.scaladsl.Source
+
+trait JournalDaoWithReadMessages {
+
+  /**
+   * Returns a Source of PersistentRepr for a certain persistenceId
+   */
+  def messages(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      max: Long): Source[Try[PersistentRepr], NotUsed]
+
+  /**
+   * Returns a Source of PersistentRepr for a certain persistenceId
+   */
+  def messagesWithBatch(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      batchSize: Int,
+      refreshInterval: Option[(FiniteDuration, Scheduler)]): Source[Try[PersistentRepr], NotUsed]
+
+}

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
@@ -9,22 +9,21 @@ package query.dao
 import akka.NotUsed
 import akka.persistence.PersistentRepr
 import akka.persistence.jdbc.config.ReadJournalConfig
+import akka.persistence.jdbc.journal.dao.BaseJournalDaoWithReadMessages
 import akka.persistence.jdbc.journal.dao.ByteArrayJournalSerializer
 import akka.persistence.jdbc.query.dao.TagFilterFlow.perfectlyMatchTag
 import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
 import akka.serialization.Serialization
 import akka.stream.Materializer
 import akka.stream.scaladsl.{ Flow, Source }
-import slick.basic.DatabasePublisher
 import slick.jdbc.JdbcProfile
 import slick.jdbc.GetResult
 import slick.jdbc.JdbcBackend._
-
 import scala.collection.immutable._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
-trait BaseByteArrayReadJournalDao extends ReadJournalDao {
+trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWithReadMessages {
   def db: Database
   val profile: JdbcProfile
   def queries: ReadJournalQueries
@@ -191,7 +190,7 @@ class ByteArrayReadJournalDao(
     val db: Database,
     val profile: JdbcProfile,
     val readJournalConfig: ReadJournalConfig,
-    serialization: Serialization)(implicit ec: ExecutionContext, mat: Materializer)
+    serialization: Serialization)(implicit val ec: ExecutionContext, val mat: Materializer)
     extends BaseByteArrayReadJournalDao
     with OracleReadJournalDao
     with H2ReadJournalDao {

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalDao.scala
@@ -9,12 +9,13 @@ package query.dao
 import akka.NotUsed
 import akka.persistence.PersistentRepr
 import akka.stream.scaladsl.Source
-
 import scala.collection.immutable._
 import scala.concurrent.Future
 import scala.util.Try
 
-trait ReadJournalDao {
+import akka.persistence.jdbc.journal.dao.JournalDaoWithReadMessages
+
+trait ReadJournalDao extends JournalDaoWithReadMessages {
 
   /**
    * Returns distinct stream of persistenceIds
@@ -31,15 +32,6 @@ trait ReadJournalDao {
       offset: Long,
       maxOffset: Long,
       max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed]
-
-  /**
-   * Returns a Source of bytes for a certain persistenceId
-   */
-  def messages(
-      persistenceId: String,
-      fromSequenceNr: Long,
-      toSequenceNr: Long,
-      max: Long): Source[Try[PersistentRepr], NotUsed]
 
   /**
    * @param offset Minimum value to retrieve

--- a/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -22,11 +22,12 @@ import akka.util.Timeout
 import com.typesafe.config.Config
 import slick.jdbc.JdbcBackend._
 import slick.jdbc.JdbcProfile
-
 import scala.collection.immutable._
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
+
+import akka.actor.Scheduler
 import akka.persistence.jdbc.util.PluginVersionChecker
 
 object JdbcReadJournal {
@@ -118,69 +119,31 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
     adapter.fromJournal(repr.payload, repr.manifest).events.map(repr.withPayload)
   }
 
-  private def currentJournalEventsByPersistenceId(
-      persistenceId: String,
-      fromSequenceNr: Long,
-      toSequenceNr: Long,
-      max: Long): Source[PersistentRepr, NotUsed] =
-    readJournalDao
-      .messages(persistenceId, fromSequenceNr, toSequenceNr, max)
-      .mapAsync(1)(deserializedRepr => Future.fromTry(deserializedRepr))
-
   override def currentEventsByPersistenceId(
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
-    eventsByPersistenceIdSource(persistenceId, fromSequenceNr, toSequenceNr, currentEventsOnly = true)
+    eventsByPersistenceIdSource(persistenceId, fromSequenceNr, toSequenceNr, None)
 
   override def eventsByPersistenceId(
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
-    eventsByPersistenceIdSource(persistenceId, fromSequenceNr, toSequenceNr, currentEventsOnly = false)
+    eventsByPersistenceIdSource(
+      persistenceId,
+      fromSequenceNr,
+      toSequenceNr,
+      Some(readJournalConfig.refreshInterval -> system.scheduler))
 
   private def eventsByPersistenceIdSource(
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long,
-      currentEventsOnly: Boolean): Source[EventEnvelope, NotUsed] = {
-    import JdbcReadJournal._
+      refreshInterval: Option[(FiniteDuration, Scheduler)]): Source[EventEnvelope, NotUsed] = {
     val batchSize = readJournalConfig.maxBufferSize
-
-    Source
-      .unfoldAsync[(Long, FlowControl), Seq[PersistentRepr]]((Math.max(1, fromSequenceNr), Continue)) {
-        case (from, control) =>
-          def retrieveNextBatch(): Future[Option[((Long, FlowControl), Seq[PersistentRepr])]] = {
-            for {
-              xs <- currentJournalEventsByPersistenceId(persistenceId, from, toSequenceNr, batchSize).runWith(Sink.seq)
-            } yield {
-              val hasMoreEvents = xs.size == batchSize
-              // Events are ordered by sequence number, therefore the last one is the largest)
-              val lastSeqNrInBatch: Option[Long] = xs.lastOption.map(_.sequenceNr)
-              val hasLastEvent = lastSeqNrInBatch.exists(_ >= toSequenceNr)
-              val nextControl: FlowControl =
-                if (hasLastEvent || from > toSequenceNr) Stop
-                else if (hasMoreEvents) Continue
-                else if (currentEventsOnly) Stop
-                else ContinueDelayed
-
-              val nextFrom: Long = lastSeqNrInBatch match {
-                // Continue querying from the last sequence number (the events are ordered)
-                case Some(lastSeqNr) => lastSeqNr + 1
-                case None            => from
-              }
-              Some((nextFrom, nextControl), xs)
-            }
-          }
-
-          control match {
-            case Stop     => Future.successful(None)
-            case Continue => retrieveNextBatch()
-            case ContinueDelayed =>
-              akka.pattern.after(readJournalConfig.refreshInterval, system.scheduler)(retrieveNextBatch())
-          }
-      }
-      .mapConcat(identity)
+    readJournalDao
+      .messagesWithBatch(persistenceId, fromSequenceNr, toSequenceNr, batchSize, refreshInterval)
+      .mapAsync(1)(deserializedRepr => Future.fromTry(deserializedRepr))
       .mapConcat(adaptEvents)
       .map(repr => EventEnvelope(Sequence(repr.sequenceNr), repr.persistenceId, repr.sequenceNr, repr.payload))
   }

--- a/core/src/test/scala/akka/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.query
+
+import java.util.UUID
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.persistence.{ AtomicWrite, PersistentRepr }
+import akka.persistence.jdbc.journal.dao.{ ByteArrayJournalDao, JournalTables }
+import akka.serialization.SerializationExtension
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.slf4j.LoggerFactory
+
+import scala.collection.immutable
+import scala.concurrent.{ Await, ExecutionContextExecutor, Future }
+import scala.concurrent.duration._
+import scala.util.{ Failure, Random, Success }
+
+object JournalDaoStreamMessagesMemoryTest {
+
+  val configOverrides: Map[String, ConfigValue] = Map("jdbc-journal.fetch-size" -> ConfigValueFactory.fromAnyRef("100"))
+}
+
+abstract class JournalDaoStreamMessagesMemoryTest(configFile: String)
+    extends QueryTestSpec(configFile, JournalDaoStreamMessagesMemoryTest.configOverrides)
+    with JournalTables {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  val journalSequenceActorConfig = readJournalConfig.journalSequenceRetrievalConfiguration
+  val journalTableCfg = journalConfig.journalTableConfiguration
+
+  import profile.api._
+
+  implicit val askTimeout = 50.millis
+
+  def generateId: Int = 0
+
+  behavior.of("Replaying Persistence Actor")
+
+  it should "stream events" in {
+    withActorSystem { implicit system: ActorSystem =>
+      withDatabase { db =>
+        val maxMem = Runtime.getRuntime.maxMemory()
+
+        // We don't want it to be too large otherwise the tests take too long to setup
+        // we also must be able to call .toInt on maxMen (see below) and we need it to stay inside the Int boundaries
+        // Moreover, the Oracle docker is limited to the size of the file on disk and we can't push too much data on it
+        // (128M seems to work for the Oracle Docker)
+        val memoryLimit = 128000000
+        if (maxMem > memoryLimit) {
+          info(
+            s"JournalDaoStreamMessagesMemoryTest can only be run with a limited amount of memory ($memoryLimit), found [$maxMem]")
+          pending
+        }
+
+        implicit val mat: ActorMaterializer = ActorMaterializer()
+        implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+        val persistenceId = UUID.randomUUID().toString
+        val dao = new ByteArrayJournalDao(db, profile, journalConfig, SerializationExtension(system))
+
+        val payloadSize = 5000 // 5000 bytes
+        val eventsPerBatch = 1000
+
+        val numberOfInsertBatches = {
+          // calculate the number of batches using a factor to make sure we go a little bit over the limit
+          (maxMem.toInt / (payloadSize * eventsPerBatch) * 1.2).round.toInt
+        }
+        val totalMessages = numberOfInsertBatches * eventsPerBatch
+        val totalMessagePayload = totalMessages * payloadSize
+        log.info(
+          s"maxMem: $maxMem, batches: $numberOfInsertBatches (with $eventsPerBatch events), total messages: $totalMessages, total msgs size: $totalMessagePayload")
+
+        // payload can be the same when inserting to avoid unnecessary memory usage
+        val payload = Array.fill(payloadSize)('a'.toByte)
+
+        val lastInsert =
+          Source
+            .fromIterator(() => (1 to numberOfInsertBatches).toIterator)
+            .mapAsync(1) { i =>
+              val end = i * eventsPerBatch
+              val start = end - (eventsPerBatch - 1)
+              log.info(s"batch $i - events from $start to $end")
+              val atomicWrites =
+                (start to end).map { j =>
+                  AtomicWrite(immutable.Seq(PersistentRepr(payload, j, persistenceId)))
+                }.toSeq
+
+              dao.asyncWriteMessages(atomicWrites).map(_ => i)
+            }
+            .runWith(Sink.last)
+
+        // wait until we write all messages
+        // being very generous, 1 second per message
+        lastInsert.futureValue(Timeout(totalMessages.seconds))
+
+        log.info("Events written, starting replay")
+
+        val messagesSrc =
+          dao.messagesWithBatch(persistenceId, 0, totalMessages, batchSize = 100, None)
+        val doneFut =
+          messagesSrc.runForeach {
+            case Success(repr) =>
+              if (repr.sequenceNr % 100 == 0)
+                log.info(s"fetched: ${repr.persistenceId} - ${repr.sequenceNr}/${totalMessages}")
+            case Failure(exception) => println(exception)
+          }
+
+        // wait until we read all messages
+        // being very generous, 1 second per message
+        doneFut.futureValue(Timeout(totalMessages.seconds))
+      }
+    }
+  }
+}
+
+class PostgresJournalDaoStreamMessagesMemoryTest
+    extends JournalDaoStreamMessagesMemoryTest("postgres-application.conf")
+    with PostgresCleaner
+
+class MySQLJournalDaoStreamMessagesMemoryTest
+    extends JournalDaoStreamMessagesMemoryTest("mysql-application.conf")
+    with MysqlCleaner
+
+class OracleJournalDaoStreamMessagesMemoryTest
+    extends JournalDaoStreamMessagesMemoryTest("oracle-application.conf")
+    with OracleCleaner
+
+class SqlServerJournalDaoStreamMessagesMemoryTest
+    extends JournalDaoStreamMessagesMemoryTest("sqlserver-application.conf")
+    with SqlServerCleaner

--- a/core/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
@@ -12,10 +12,11 @@ import akka.stream.scaladsl.Source
 import akka.testkit.TestProbe
 import akka.util.Timeout
 import akka.pattern.ask
-
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Try
+
+import akka.actor.Scheduler
 
 object TestProbeReadJournalDao {
   case class JournalSequence(offset: Long, limit: Long)
@@ -52,6 +53,13 @@ class TestProbeReadJournalDao(val probe: TestProbe) extends ReadJournalDao {
       toSequenceNr: Long,
       max: Long): Source[Try[PersistentRepr], NotUsed] = ???
 
+  override def messagesWithBatch(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      batchSize: Int,
+      refreshInterval: Option[(FiniteDuration, Scheduler)]): Source[Try[PersistentRepr], NotUsed] = ???
+
   /**
    * @param offset Minimum value to retrieve
    * @param limit  Maximum number of values to retrieve
@@ -66,4 +74,5 @@ class TestProbeReadJournalDao(val probe: TestProbe) extends ReadJournalDao {
    * @return The value of the maximum (ordering) id in the journal
    */
   override def maxJournalSequence(): Future[Long] = Future.successful(0)
+
 }

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -313,8 +313,7 @@ jdbc-read-journal {
 Storing messages as byte arrays in blobs is not the only way to store information in a database. For example, you could store messages with full type information as a normal database rows, each event type having its own table.
 For example, implementing a Journal Log table that stores all persistenceId, sequenceNumber and event type discriminator field, and storing the event data in another table with full typing
 
-You only have to implement two interfaces `akka.persistence.jdbc.journal.dao.JournalDao` and/or `akka.persistence.jdbc.snapshot.dao.SnapshotDao`. As these APIs are only now exposed for public use, the interfaces may change when the API needs to
-change for whatever reason.
+You only have to implement two interfaces `akka.persistence.jdbc.journal.dao.JournalDao` and/or `akka.persistence.jdbc.snapshot.dao.SnapshotDao`. 
 
 For example, take a look at the following two custom DAOs:
 
@@ -332,6 +331,14 @@ As you can see, the custom DAOs get a _Slick database_, a _Slick profile_, the j
 You should register the Fully Qualified Class Name in `application.conf` so that the custom DAOs will be used.
 
 For more information please review the two default implementations `akka.persistence.jdbc.dao.bytea.journal.ByteArrayJournalDao` and `akka.persistence.jdbc.dao.bytea.snapshot.ByteArraySnapshotDao` or the demo custom DAO example from the [demo-akka-persistence](https://github.com/dnvriend/demo-akka-persistence-jdbc) site.
+
+@@@warning { title="Binary compatibility" }
+
+The APIs for custom DAOs are not guaranteed to be binary backwards compatible between major versions of the plugin.
+For example 4.0.0 is not binary backwards compatible with 3.5.x. There may also be source incompatible changes of
+the APIs for customer DAOs if new capabilities must be added to to the traits.
+
+@@@
 
 ## Explicitly shutting down the database connections
 


### PR DESCRIPTION
* otherwise some DBs will load everything into memory
* used the existing implementation from JdbcReadJournal.eventsByPersistenceId,
  but moved it to DAO layer so that it could be used from both
  JdbcAsyncWriteJournal and JdbcReadJournal
* new config replayBatchSize

also included the test from https://github.com/akka/akka-persistence-jdbc/pull/351

References #322
