### PR TITLE
Use ordering Offset in eventsByPersistenceId, #91

### DIFF
--- a/core/src/main/mima-filters/3.5.3.backwards.excludes/issue-91-ordering-offset.excludes
+++ b/core/src/main/mima-filters/3.5.3.backwards.excludes/issue-91-ordering-offset.excludes
@@ -1,0 +1,8 @@
+# #91 changing signature of messages and messagesWithBatch in JournalDaoWithReadMessages
+#     tuple (PersistentRepr, Long) to include the ordering number
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.jdbc.serialization.FlowPersistentReprSerializer.deserializeFlowWithoutTags")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.jdbc.journal.dao.ByteArrayJournalSerializer.deserializeFlowWithoutTags")
+ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.query.scaladsl.JdbcReadJournal$ContinueDelayed$")
+ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.query.scaladsl.JdbcReadJournal$FlowControl")
+ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.query.scaladsl.JdbcReadJournal$Stop$")
+ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.query.scaladsl.JdbcReadJournal$Continue$")

--- a/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -121,8 +121,10 @@ class JdbcAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
     journalDao
       .messagesWithBatch(persistenceId, fromSequenceNr, toSequenceNr, journalConfig.daoConfig.replayBatchSize, None)
       .take(max)
-      .mapAsync(1)(deserializedRepr => Future.fromTry(deserializedRepr))
-      .runForeach(recoveryCallback)
+      .mapAsync(1)(reprAndOrdNr => Future.fromTry(reprAndOrdNr))
+      .runForeach {
+        case (repr, _) => recoveryCallback(repr)
+      }
       .map(_ => ())
 
   override def postStop(): Unit = {

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/FlowControl.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/FlowControl.scala
@@ -1,6 +1,8 @@
 /*
- * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.persistence.jdbc.journal.dao
 
 private[jdbc] sealed trait FlowControl

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/FlowControl.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/FlowControl.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.persistence.jdbc.journal.dao
+
+private[jdbc] sealed trait FlowControl
+
+private[jdbc] object FlowControl {
+
+  /** Keep querying - used when we are sure that there is more events to fetch */
+  case object Continue extends FlowControl
+
+  /**
+   * Keep querying with delay - used when we have consumed all events,
+   * but want to poll for future events
+   */
+  case object ContinueDelayed extends FlowControl
+
+  /** Stop querying - used when we reach the desired offset  */
+  case object Stop extends FlowControl
+}

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDaoWithReadMessages.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDaoWithReadMessages.scala
@@ -16,22 +16,26 @@ import akka.stream.scaladsl.Source
 trait JournalDaoWithReadMessages {
 
   /**
-   * Returns a Source of PersistentRepr for a certain persistenceId
+   * Returns a Source of PersistentRepr and ordering number for a certain persistenceId.
+   * It includes the events with sequenceNr between `fromSequenceNr` (inclusive) and
+   * `toSequenceNr` (inclusive).
    */
   def messages(
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long,
-      max: Long): Source[Try[PersistentRepr], NotUsed]
+      max: Long): Source[Try[(PersistentRepr, Long)], NotUsed]
 
   /**
-   * Returns a Source of PersistentRepr for a certain persistenceId
+   * Returns a Source of PersistentRepr and ordering number for a certain persistenceId.
+   * It includes the events with sequenceNr between `fromSequenceNr` (inclusive) and
+   * `toSequenceNr` (inclusive).
    */
   def messagesWithBatch(
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long,
       batchSize: Int,
-      refreshInterval: Option[(FiniteDuration, Scheduler)]): Source[Try[PersistentRepr], NotUsed]
+      refreshInterval: Option[(FiniteDuration, Scheduler)]): Source[Try[(PersistentRepr, Long)], NotUsed]
 
 }

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -83,4 +83,19 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Jou
       .take(max)
 
   val messagesQuery = Compiled(_messagesQuery _)
+
+  private def _messagesByOrderingQuery(
+      persistenceId: Rep[String],
+      fromOrderingNr: Rep[Long],
+      toOrderingNr: Rep[Long],
+      max: ConstColumn[Long]) =
+    JournalTable
+      .filter(_.persistenceId === persistenceId)
+      .filter(_.deleted === false)
+      .filter(_.ordering > fromOrderingNr)
+      .filter(_.ordering <= toOrderingNr)
+      .sortBy(_.ordering.asc)
+      .take(max)
+
+  val messagesByOrderingQuery = Compiled(_messagesByOrderingQuery _)
 }

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -84,18 +84,4 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Jou
 
   val messagesQuery = Compiled(_messagesQuery _)
 
-  private def _messagesByOrderingQuery(
-      persistenceId: Rep[String],
-      fromOrderingNr: Rep[Long],
-      toOrderingNr: Rep[Long],
-      max: ConstColumn[Long]) =
-    JournalTable
-      .filter(_.persistenceId === persistenceId)
-      .filter(_.deleted === false)
-      .filter(_.ordering > fromOrderingNr)
-      .filter(_.ordering <= toOrderingNr)
-      .sortBy(_.ordering.asc)
-      .take(max)
-
-  val messagesByOrderingQuery = Compiled(_messagesByOrderingQuery _)
 }

--- a/core/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
@@ -25,18 +25,68 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal)
     with CurrentEventsByTagQuery
     with EventsByTagQuery {
 
+  /**
+   * Same type of query as `persistenceIds` but the event stream
+   * is completed immediately when it reaches the end of the "result set". Events that are
+   * stored after the query is completed are not included in the event stream.
+   */
   override def currentPersistenceIds(): Source[String, NotUsed] =
     journal.currentPersistenceIds().asJava
 
+  /**
+   * `persistenceIds` is used to retrieve a stream of all `persistenceId`s as strings.
+   *
+   * The stream guarantees that a `persistenceId` is only emitted once and there are no duplicates.
+   * Order is not defined. Multiple executions of the same stream (even bounded) may emit different
+   * sequence of `persistenceId`s.
+   *
+   * The stream is not completed when it reaches the end of the currently known `persistenceId`s,
+   * but it continues to push new `persistenceId`s when new events are persisted.
+   * Corresponding query that is completed when it reaches the end of the currently
+   * known `persistenceId`s is provided by `currentPersistenceIds`.
+   */
   override def persistenceIds(): Source[String, NotUsed] =
     journal.persistenceIds().asJava
 
+  /**
+   * Same type of query as `eventsByPersistenceId` but the event stream
+   * is completed immediately when it reaches the end of the "result set". Events that are
+   * stored after the query is completed are not included in the event stream.
+   */
   override def currentEventsByPersistenceId(
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     journal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
+  /**
+   * `eventsByPersistenceId` is used to retrieve a stream of events for a particular persistenceId.
+   *
+   * The `EventEnvelope` contains the event and provides `persistenceId` and `sequenceNr`
+   * for each event. The `sequenceNr` is the sequence number for the persistent actor with the
+   * `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
+   * identifier for the event.
+   *
+   * `fromSequenceNr` and `toSequenceNr` can be specified to limit the set of returned events.
+   * The `fromSequenceNr` and `toSequenceNr` are inclusive.
+   *
+   * The `EventEnvelope` also provides the `offset` that corresponds to the `ordering` column in
+   * the Journal table. The `ordering` is a sequential id number that uniquely identifies the
+   * position of each event, also across different `persistenceId`. The `Offset` type is
+   * `akka.persistence.query.Sequence` with the `ordering` as the offset value. This is the
+   * same `ordering` number as is used in the offset of the `eventsByTag` query.
+   *
+   * The returned event stream is ordered by `sequenceNr`.
+   *
+   * Causality is guaranteed (`sequenceNr`s of events for a particular `persistenceId` are always ordered
+   * in a sequence monotonically increasing by one). Multiple executions of the same bounded stream are
+   * guaranteed to emit exactly the same stream of events.
+   *
+   * The stream is not completed when it reaches the end of the currently stored events,
+   * but it continues to push new events when new events are persisted.
+   * Corresponding query that is completed when it reaches the end of the currently
+   * stored events is provided by `currentEventsByPersistenceId`.
+   */
   override def eventsByPersistenceId(
       persistenceId: String,
       fromSequenceNr: Long,
@@ -44,15 +94,9 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal)
     journal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**
-   * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
+   * Same type of query as `eventsByTag` but the event stream
    * is completed immediately when it reaches the end of the "result set". Events that are
    * stored after the query is completed are not included in the event stream.
-   *
-   * akka-persistence-jdbc has implemented this feature by using a LIKE %tag% query on the tags column.
-   * A consequence of this is that tag names must be chosen wisely: for example when querying the tag `User`,
-   * events with the tag `UserEmail` will also be returned (since User is a substring of UserEmail).
-   *
-   * The returned event stream is ordered by `offset`.
    */
   override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     journal.currentEventsByTag(tag, offset).asJava
@@ -66,10 +110,13 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal)
    *
    * The consumer can keep track of its current position in the event stream by storing the
    * `offset` and restart the query from a given `offset` after a crash/restart.
+   * The offset is exclusive, i.e. the event corresponding to the given `offset` parameter is not
+   * included in the stream.
    *
    * For akka-persistence-jdbc the `offset` corresponds to the `ordering` column in the Journal table.
    * The `ordering` is a sequential id number that uniquely identifies the position of each event within
-   * the event stream.
+   * the event stream. The `Offset` type is `akka.persistence.query.Sequence` with the `ordering` as the
+   * offset value.
    *
    * The returned event stream is ordered by `offset`.
    *

--- a/core/src/main/scala/akka/persistence/jdbc/serialization/PersistentReprSerializer.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/serialization/PersistentReprSerializer.scala
@@ -53,10 +53,4 @@ trait FlowPersistentReprSerializer[T] extends PersistentReprSerializer[T] {
     Flow[T].map(deserialize)
   }
 
-  def deserializeFlowWithoutTags: Flow[T, Try[PersistentRepr], NotUsed] = {
-    def keepPersistentRepr(tup: (PersistentRepr, Set[String], Long)): PersistentRepr = tup match {
-      case (repr, _, _) => repr
-    }
-    deserializeFlow.map(_.map(keepPersistentRepr))
-  }
 }

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
@@ -8,10 +8,13 @@ package akka.persistence.jdbc.query
 import akka.Done
 import akka.persistence.Persistence
 import akka.persistence.jdbc.journal.JdbcAsyncWriteJournal
+import akka.persistence.query.Offset
 import akka.persistence.query.{ EventEnvelope, Sequence }
 import akka.testkit.TestProbe
 
 abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTestSpec(config) {
+  import QueryTestSpec.EventEnvelopeProbeOps
+
   it should "not find any events for unknown pid" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     journalOps.withCurrentEventsByPersistenceId()("unkown-pid", 0L, Long.MaxValue) { tp =>
@@ -20,7 +23,7 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
     }
   }
 
-  it should "find events from an offset" in withActorSystem { implicit system =>
+  it should "find events from sequenceNr" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors() { (actor1, actor2, actor3) =>
       actor1 ! 1
@@ -34,7 +37,7 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 0, 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
+        tp.expectNextEventEnvelope("my-1", 1, 1)
         tp.expectComplete()
       }
 
@@ -88,6 +91,54 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
     }
   }
 
+  it should "include ordering Offset in EventEnvelope" in withActorSystem { implicit system =>
+    val journalOps = new ScalaJdbcReadJournalOperations(system)
+    withTestActors() { (actor1, actor2, actor3) =>
+      actor1 ! 1
+      actor1 ! 2
+      actor1 ! 3
+
+      eventually {
+        journalOps.countJournal.futureValue shouldBe 3
+      }
+
+      actor2 ! 4
+      eventually {
+        journalOps.countJournal.futureValue shouldBe 4
+      }
+
+      actor3 ! 5
+      eventually {
+        journalOps.countJournal.futureValue shouldBe 5
+      }
+
+      actor1 ! 6
+      eventually {
+        journalOps.countJournal.futureValue shouldBe 6
+      }
+
+      journalOps.withCurrentEventsByPersistenceId()("my-1", 0, Long.MaxValue) { tp =>
+        tp.request(Int.MaxValue)
+        tp.expectNextEventEnvelope("my-1", 1, 1)
+        tp.expectNextEventEnvelope("my-1", 2, 2)
+
+        val env3 = tp.expectNext(ExpectNextTimeout)
+        val ordering3 = env3.offset match {
+          case Sequence(value) => value
+        }
+
+        val env6 = tp.expectNext(ExpectNextTimeout)
+        env6.persistenceId shouldBe "my-1"
+        env6.sequenceNr shouldBe 4
+        env6.event shouldBe 6
+        // event 4 and 5 persisted before 6 by different actors, increasing the ordering
+        env6.offset shouldBe Offset.sequence(ordering3 + 3)
+
+        tp.expectComplete()
+      }
+    }
+  }
+
   it should "find events for actors" in withActorSystem { implicit system =>
     val journalOps = new JavaDslJdbcReadJournalOperations(system)
     withTestActors() { (actor1, actor2, actor3) =>
@@ -100,21 +151,21 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1)).expectComplete()
+        tp.request(Int.MaxValue).expectNextEventEnvelope("my-1", 1, 1).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2)).expectComplete()
+        tp.request(Int.MaxValue).expectNextEventEnvelope("my-1", 2, 2).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3)).expectComplete()
+        tp.request(Int.MaxValue).expectNextEventEnvelope("my-1", 3, 3).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
+          .expectNextEventEnvelope("my-1", 2, 2)
+          .expectNextEventEnvelope("my-1", 3, 3)
           .expectComplete()
       }
     }
@@ -136,9 +187,9 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
       val pid = "my-1"
       journalOps.withCurrentEventsByPersistenceId()(pid, 1, 3) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), pid, 1, 1))
-          .expectNext(EventEnvelope(Sequence(2), pid, 2, 2))
-          .expectNext(EventEnvelope(Sequence(3), pid, 3, 3))
+          .expectNextEventEnvelope(pid, 1, 1)
+          .expectNextEventEnvelope(pid, 2, 2)
+          .expectNextEventEnvelope(pid, 3, 3)
           .expectComplete()
       }
 
@@ -149,9 +200,9 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
 
       journalOps.withCurrentEventsByPersistenceId()(pid, 1, 3) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(1), pid, 1, Integer.valueOf(111)))
-          .expectNext(EventEnvelope(Sequence(2), pid, 2, 2))
-          .expectNext(EventEnvelope(Sequence(3), pid, 3, 3))
+          .expectNextEventEnvelope(pid, 1, Integer.valueOf(111))
+          .expectNextEventEnvelope(pid, 2, 2)
+          .expectNextEventEnvelope(pid, 3, 3)
           .expectComplete()
       }
     }

--- a/core/src/test/scala/akka/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
@@ -113,7 +113,7 @@ abstract class JournalDaoStreamMessagesMemoryTest(configFile: String)
         val probe =
           messagesSrc
             .map {
-              case Success(repr) =>
+              case Success((repr, _)) =>
                 if (repr.sequenceNr % 100 == 0)
                   log.info(s"fetched: ${repr.persistenceId} - ${repr.sequenceNr}/${totalMessages}")
               case Failure(exception) =>

--- a/core/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/dao/TestProbeReadJournalDao.scala
@@ -51,14 +51,14 @@ class TestProbeReadJournalDao(val probe: TestProbe) extends ReadJournalDao {
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long,
-      max: Long): Source[Try[PersistentRepr], NotUsed] = ???
+      max: Long): Source[Try[(PersistentRepr, Long)], NotUsed] = ???
 
   override def messagesWithBatch(
       persistenceId: String,
       fromSequenceNr: Long,
       toSequenceNr: Long,
       batchSize: Int,
-      refreshInterval: Option[(FiniteDuration, Scheduler)]): Source[Try[PersistentRepr], NotUsed] = ???
+      refreshInterval: Option[(FiniteDuration, Scheduler)]): Source[Try[(PersistentRepr, Long)], NotUsed] = ???
 
   /**
    * @param offset Minimum value to retrieve


### PR DESCRIPTION
* to be able to correlate between eventsByPersistenceId and eventsByTag
* seqNr is anyway in the EventEnvelope
* changing signature of messages and messagesWithBatch in JournalDaoWithReadMessages
  * tuple (PersistentRepr, Long) to include the ordering number
* Scaladoc clarifications of the queries

References #91
