### PR TITLE
Update to Akka 2.6.4 and ScalaTest 3.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - stage: test
       env:
         - PRE_CMD="./scripts/launch-all.sh"
-        - CMD="++2.12.10 test"
+        - CMD="++2.12.11 test"
       name: "Run tests with Scala 2.12 and AdoptOpenJDK 8"
     - env:
         - PRE_CMD="./scripts/launch-all.sh"

--- a/core/src/test/scala/akka/persistence/jdbc/SimpleSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/SimpleSpec.scala
@@ -10,9 +10,11 @@ import akka.persistence.jdbc.util.ClasspathResources
 import akka.testkit.TestProbe
 import org.scalatest._
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 trait SimpleSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ScalaFutures
     with TryValues

--- a/core/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
@@ -7,9 +7,10 @@ package akka.persistence.jdbc
 
 import akka.persistence.jdbc.config._
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-abstract class TablesTestSpec extends FlatSpec with Matchers {
+abstract class TablesTestSpec extends AnyFlatSpec with Matchers {
   def toColumnName[A](tableName: String)(columnName: String): String = s"$tableName.$columnName"
 
   val config = ConfigFactory.parseString(

--- a/core/src/test/scala/akka/persistence/jdbc/configuration/AkkaPersistenceConfigTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/configuration/AkkaPersistenceConfigTest.scala
@@ -7,11 +7,12 @@ package akka.persistence.jdbc.configuration
 
 import akka.persistence.jdbc.config._
 import com.typesafe.config.{ Config, ConfigFactory }
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.duration._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class AkkaPersistenceConfigTest extends FlatSpec with Matchers {
+class AkkaPersistenceConfigTest extends AnyFlatSpec with Matchers {
   val config: Config = ConfigFactory.parseString(
     """
       |jdbc-journal {

--- a/core/src/test/scala/akka/persistence/jdbc/query/HardDeleteQueryTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/HardDeleteQueryTest.scala
@@ -9,9 +9,9 @@ import akka.persistence.query.{ EventEnvelope, NoOffset, Sequence }
 import akka.pattern._
 import com.typesafe.config.ConfigFactory
 import org.scalactic.source.Position
-import org.scalatest.Matchers
 
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
 
 abstract class HardDeleteQueryTest(config: String) extends QueryTestSpec(config) with Matchers {
   implicit val askTimeout = 500.millis

--- a/core/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
@@ -35,9 +35,6 @@ abstract class JournalSequenceActorTest(configFile: String, isOracle: Boolean)
 
   implicit val askTimeout = 50.millis
 
-  implicit val patience: PatienceConfig =
-    PatienceConfig(10.seconds, Span(200, org.scalatest.time.Millis))
-
   def generateId: Int = 0
 
   behavior.of("JournalSequenceActor")
@@ -77,10 +74,11 @@ abstract class JournalSequenceActorTest(configFile: String, isOracle: Boolean)
 
           val startTime = System.currentTimeMillis()
           withJournalSequenceActor(db, maxTries = 100) { actor =>
+            val patienceConfig = PatienceConfig(10.seconds, Span(200, org.scalatest.time.Millis))
             eventually {
               val currentMax = actor.ask(GetMaxOrderingId).mapTo[MaxOrderingId].futureValue.maxOrdering
               currentMax shouldBe elements
-            }
+            }(patienceConfig, implicitly, implicitly)
           }
           val timeTaken = System.currentTimeMillis() - startTime
           log.info(s"Recovered all events in $timeTaken ms")
@@ -111,10 +109,11 @@ abstract class JournalSequenceActorTest(configFile: String, isOracle: Boolean)
 
           withJournalSequenceActor(db, maxTries = 2) { actor =>
             // Should normally recover after `maxTries` seconds
+            val patienceConfig = PatienceConfig(10.seconds, Span(200, org.scalatest.time.Millis))
             eventually {
               val currentMax = actor.ask(GetMaxOrderingId).mapTo[MaxOrderingId].futureValue.maxOrdering
               currentMax shouldBe lastElement
-            }
+            }(patienceConfig, implicitly, implicitly)
           }
         }
       }
@@ -151,7 +150,7 @@ abstract class JournalSequenceActorTest(configFile: String, isOracle: Boolean)
             eventually {
               val currentMax = actor.ask(GetMaxOrderingId).mapTo[MaxOrderingId].futureValue.maxOrdering
               currentMax shouldBe highestValue
-            }
+            }(patienceConfig, implicitly, implicitly)
           }
         }
       }

--- a/migration/src/test/scala/akka/persistence/jdbc/migration/PostgresSpec.scala
+++ b/migration/src/test/scala/akka/persistence/jdbc/migration/PostgresSpec.scala
@@ -9,10 +9,12 @@ import java.sql.{ Connection, DriverManager }
 import java.util.Properties
 
 import com.typesafe.config.{ Config, ConfigFactory }
-import org.scalatest.{ BeforeAndAfterAll, FlatSpec, Matchers }
+import org.scalatest.BeforeAndAfterAll
 import org.testcontainers.containers.PostgreSQLContainer
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PostgresSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class PostgresSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   val postgres: PostgreSQLContainer[_] = {
     val c = new PostgreSQLContainer()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,15 +5,15 @@ object Dependencies {
   val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
 
   // Keep in sync with .travis.yml
-  val Scala212 = "2.12.10"
+  val Scala212 = "2.12.11"
   val Scala213 = "2.13.1"
   val ScalaVersions = Seq(Scala212, Scala213)
 
-  val AkkaVersion = if (Nightly) "2.6.0" else "2.5.29"
-  val AkkaBinaryVersion = if (Nightly) "2.6" else "2.5"
+  val AkkaVersion = "2.6.4"
+  val AkkaBinaryVersion = "2.6"
 
   val SlickVersion = "3.3.2"
-  val ScalaTestVersion = "3.0.8"
+  val ScalaTestVersion = "3.1.1"
 
   val JdbcDrivers = Seq(
     "org.postgresql" % "postgresql" % "42.2.12",


### PR DESCRIPTION
* removing support for Akka 2.5.x because we can't run persistence-tck
  tests with both Akka 2.5 and 2.6 due to different ScalaTest versions
* for the 4.0.0 release we don't want to support Akka 2.5.x anyway,
  users that need to stay on Akka 2.5 can use the old akka-persistence-jdbc 3.5.x
  version

