### PR TITLE
Make Scala Steward less aggressive

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,12 +1,9 @@
-updates.ignore = [
-  // explicit updates
-  { groupId = "com.typesafe.akka", artifactId = "akka-actor" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-persistence" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-persistence-query" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-stream" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-slf4j" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-persistence-tck" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-stream-testkit" },
-  { groupId = "com.typesafe.akka", artifactId = "akka-testkit" }
+pullRequests.frequency = "@monthly"
+
+updates.pin = [
+  { groupId = "com.typesafe.akka", version = "2.6." }
 ]
-updatePullRequests = false
+
+commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+updatePullRequests = never


### PR DESCRIPTION
Change Scala Steward to suggest updates just once a month.

Pin Akka libraries to 2.6 (get PRs for patch releases).