### PR TITLE
Reduce amount of config variables

### DIFF
--- a/core/src/test/resources/mysql-application.conf
+++ b/core/src/test/resources/mysql-application.conf
@@ -48,14 +48,10 @@ slick {
   profile = "slick.jdbc.MySQLProfile$"
   db {
     host = ${docker.host}
-    host = ${?MYSQL_HOST}
-    port = "3306"
-    port = ${?MYSQL_PORT}
-    url = "jdbc:mysql://"${slick.db.host}":"${slick.db.port}"/mysql?cachePrepStmts=true&cacheCallableStmts=true&cacheServerConfiguration=true&useLocalSessionState=true&elideSetAutoCommits=true&alwaysSendSetIsolation=false&enableQueryTimeouts=false&connectionAttributes=none&verifyServerCertificate=false&useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&useLegacyDatetimeCode=false&serverTimezone=UTC&rewriteBatchedStatements=true"
+    host = ${?DB_HOST}
+    url = "jdbc:mysql://"${slick.db.host}":3306/mysql?cachePrepStmts=true&cacheCallableStmts=true&cacheServerConfiguration=true&useLocalSessionState=true&elideSetAutoCommits=true&alwaysSendSetIsolation=false&enableQueryTimeouts=false&connectionAttributes=none&verifyServerCertificate=false&useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&useLegacyDatetimeCode=false&serverTimezone=UTC&rewriteBatchedStatements=true"
     user = "root"
-    user = ${?MYSQL_USER}
     password = "root"
-    password = ${?MYSQL_PASSWORD}
     driver = "com.mysql.cj.jdbc.Driver"
     numThreads = 5
     maxConnections = 5

--- a/core/src/test/resources/mysql-shared-db-application.conf
+++ b/core/src/test/resources/mysql-shared-db-application.conf
@@ -35,14 +35,10 @@ akka-persistence-jdbc {
       profile = "slick.jdbc.MySQLProfile$"
       db {
         host = ${docker.host}
-        host = ${?MYSQL_HOST}
-        port = "3306"
-        port = ${?MYSQL_PORT}
-        url = "jdbc:mysql://"${akka-persistence-jdbc.shared-databases.slick.db.host}":"${akka-persistence-jdbc.shared-databases.slick.db.port}"/mysql?cachePrepStmts=true&cacheCallableStmts=true&cacheServerConfiguration=true&useLocalSessionState=true&elideSetAutoCommits=true&alwaysSendSetIsolation=false&enableQueryTimeouts=false&connectionAttributes=none&verifyServerCertificate=false&useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&useLegacyDatetimeCode=false&serverTimezone=UTC&rewriteBatchedStatements=true"
+        host = ${?DB_HOST}
+        url = "jdbc:mysql://"${akka-persistence-jdbc.shared-databases.slick.db.host}":3306/mysql?cachePrepStmts=true&cacheCallableStmts=true&cacheServerConfiguration=true&useLocalSessionState=true&elideSetAutoCommits=true&alwaysSendSetIsolation=false&enableQueryTimeouts=false&connectionAttributes=none&verifyServerCertificate=false&useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&useLegacyDatetimeCode=false&serverTimezone=UTC&rewriteBatchedStatements=true"
         user = "root"
-        user = ${?MYSQL_USER}
         password = "root"
-        password = ${?MYSQL_PASSWORD}
         driver = "com.mysql.cj.jdbc.Driver"
         numThreads = 5
         maxConnections = 5

--- a/core/src/test/resources/oracle-application.conf
+++ b/core/src/test/resources/oracle-application.conf
@@ -68,12 +68,10 @@ slick {
   profile = "slick.jdbc.OracleProfile$"
   db {
     host = ${docker.host}
-    host = ${?ORACLE_HOST}
+    host = ${?DB_HOST}
     url = "jdbc:oracle:thin:@//"${slick.db.host}":1521/xe"
     user = "system"
-    user = ${?ORACLE_USER}
     password = "oracle"
-    password = ${?ORACLE_PASSWORD}
     driver = "oracle.jdbc.OracleDriver"
     numThreads = 5
     maxConnections = 5

--- a/core/src/test/resources/oracle-shared-db-application.conf
+++ b/core/src/test/resources/oracle-shared-db-application.conf
@@ -35,12 +35,10 @@ akka-persistence-jdbc {
       profile = "slick.jdbc.OracleProfile$"
       db {
         host = ${docker.host}
-        host = ${?ORACLE_HOST}
+        host = ${?DB_HOST}
         url = "jdbc:oracle:thin:@//"${akka-persistence-jdbc.shared-databases.slick.db.host}":1521/xe"
         user = "system"
-        user = ${?ORACLE_USER}
         password = "oracle"
-        password = ${?ORACLE_PASSWORD}
         driver = "oracle.jdbc.OracleDriver"
         numThreads = 5
         maxConnections = 5

--- a/core/src/test/resources/postgres-application.conf
+++ b/core/src/test/resources/postgres-application.conf
@@ -48,12 +48,10 @@ slick {
   profile = "slick.jdbc.PostgresProfile$"
   db {
     host = "localhost"
-    host = ${?POSTGRES_HOST}
+    host = ${?DB_HOST}
     url = "jdbc:postgresql://"${slick.db.host}":5432/docker?reWriteBatchedInserts=true"
     user = "docker"
-    user = ${?POSTGRES_USER}
     password = "docker"
-    password = ${?POSTGRES_PASSWORD}
     driver = "org.postgresql.Driver"
     numThreads = 5
     maxConnections = 5

--- a/core/src/test/resources/postgres-shared-db-application.conf
+++ b/core/src/test/resources/postgres-shared-db-application.conf
@@ -35,12 +35,10 @@ akka-persistence-jdbc {
       profile = "slick.jdbc.PostgresProfile$"
       db {
         host = "localhost"
-        host = ${?POSTGRES_HOST}
+        host = ${?DB_HOST}
         url = "jdbc:postgresql://"${akka-persistence-jdbc.shared-databases.slick.db.host}":5432/docker?reWriteBatchedInserts=true"
         user = "docker"
-        user = ${?POSTGRES_USER}
         password = "docker"
-        password = ${?POSTGRES_PASSWORD}
         driver = "org.postgresql.Driver"
         numThreads = 5
         maxConnections = 5

--- a/core/src/test/resources/sqlserver-application.conf
+++ b/core/src/test/resources/sqlserver-application.conf
@@ -68,14 +68,10 @@ slick {
   profile = "slick.jdbc.SQLServerProfile$"
   db {
     host = ${docker.host}
-    host = ${?SQLSERVER_HOST}
-    port = "1433"
-    port = ${?SQLSERVER_PORT}
-    url = "jdbc:sqlserver://"${slick.db.host}":"${slick.db.port}";databaseName=docker;integratedSecurity=false"
+    host = ${?DB_HOST}
+    url = "jdbc:sqlserver://"${slick.db.host}":1433;databaseName=docker;integratedSecurity=false"
     user = "docker"
-    user = ${?SQLSERVER_USER}
     password = "docker"
-    password = ${?SQLSERVER_PASSWORD}
     driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
     numThreads = 5
     maxConnections = 5

--- a/core/src/test/resources/sqlserver-shared-db-application.conf
+++ b/core/src/test/resources/sqlserver-shared-db-application.conf
@@ -35,14 +35,10 @@ akka-persistence-jdbc {
       profile = "slick.jdbc.SQLServerProfile$"
       db {
         host = ${docker.host}
-        host = ${?SQLSERVER_HOST}
+        host = ${?DB_HOST}
         url = "jdbc:sqlserver://"${akka-persistence-jdbc.shared-databases.slick.db.host}":1433;databaseName=docker;integratedSecurity=false;"
         user = "docker"
-        user = ${?SQLSERVER_USER}
-        // This password needs to include at least 8 characters of at least three of these four categories:
-        // uppercase letters, lowercase letters, numbers and non-alphanumeric symbols.
         password = "docker"
-        password = ${?SQLSERVER_PASSWORD}
         driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
         numThreads = 5
         maxConnections = 5


### PR DESCRIPTION
It seems that the CRON job is failing for quite some time. 

I saw two kind of errors, both related to variable substitution for the MySQL and Postgres. It fails consistently in CRON jobs, but I have also seen some master and PR jobs failing with that. 

It's not clear to me why this was not failing all the time. For instance, the Travis build was defining `POSTGRES_USER` to be `postgres` and `POSTGRES_PASSWORD` to be `` (for all builds). That should never work because the docker has it fixed to `docker:docker`, still we see the build pass for PRs and after merging to master.

This PR reduces the amount of lose parts. We don't need to have variable substitution, except for the DB_HOST. 
