### PR TITLE
poolName defined for different connection pools

### DIFF
--- a/core/src/test/resources/postgres-application.conf
+++ b/core/src/test/resources/postgres-application.conf
@@ -32,16 +32,19 @@ akka {
 
 jdbc-journal {
   slick = ${slick}
+  slick.db.poolName = "write-journal"
 }
 
 # the akka-persistence-snapshot-store in use
 jdbc-snapshot-store {
   slick = ${slick}
+  slick.db.poolName = "snapshot-store"
 }
 
 # the akka-persistence-query provider in use
 jdbc-read-journal {
   slick = ${slick}
+  slick.db.poolName = "read-journal"
 }
 
 slick {


### PR DESCRIPTION
When DB configuration is reused it's wise to set up different connection pool name for monitoring/debugging purposes. I would said that having 3 connection pools with same name is bad practice, so it should not be in reference conf.