### PR TITLE
fix(#451): provide the plugin configuration when looking for the eventAdapters

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -52,7 +52,9 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
   val readJournalConfig = new ReadJournalConfig(config)
 
   private val writePluginId = config.getString("write-plugin")
-  private val eventAdapters = Persistence(system).adaptersFor(writePluginId)
+  // If 'config' is empty, or if the plugin reference is not found, then the write plugin will be resolved from the
+  // ActorSystem configuration. Otherwise, it will be resolved from the provided 'config'.
+  private val eventAdapters = Persistence(system).adaptersFor(writePluginId, config)
 
   val readJournalDao: ReadJournalDao = {
     val slickDb = SlickExtension(system).database(config)


### PR DESCRIPTION
References #451

The write-plugin is resolved using the default actor system configuration and then doesn't support an eventual configuration provided at runtime.

The PR resolves this issue by providing the runtime plugin configuration while fetching the event adapters. If the plugin configuration is empty, or if the plugin reference is not found, it will be resolved using the config of the actor system, for retro-compatibility.