### PR TITLE
MiMa: detect previous version; allow change from #401

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,8 @@ lazy val core = project
     libraryDependencies ++= Dependencies.Libraries,
     mimaReportSignatureProblems := true,
     mimaPreviousArtifacts := Set(
-      organization.value %% name.value % previousStableVersion.value
-        .getOrElse(throw new Error("Unable to determine previous version for MiMa"))
-    ))
+        organization.value %% name.value % previousStableVersion.value.getOrElse(
+          throw new Error("Unable to determine previous version for MiMa"))))
 
 lazy val migration = project
   .in(file("migration"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,4 @@
 import com.lightbend.paradox.apidoc.ApidocPlugin.autoImport.apidocRootPackage
-import com.typesafe.tools.mima.core._
-import com.typesafe.tools.mima.plugin.MimaKeys.mimaBinaryIssueFilters
 
 lazy val `akka-persistence-jdbc` = project
   .in(file("."))
@@ -16,26 +14,11 @@ lazy val core = project
   .settings(
     name := "akka-persistence-jdbc",
     libraryDependencies ++= Dependencies.Libraries,
-    mimaBinaryIssueFilters ++= Seq(
-        // in 3.6.0 we intentionally renamed package akka.persistence.jdbc.util to akka.persistence.jdbc.db
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.SlickDatabaseProvider"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.SlickDatabase$"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.SlickDatabase"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.EagerSlickDatabase"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.SlickDriver$"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.SlickExtension"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.LazySlickDatabase"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.SlickExtensionImpl"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.SlickDriver"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.EagerSlickDatabase$"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.SlickExtension$"),
-        ProblemFilters.exclude[MissingClassProblem]("akka.persistence.jdbc.util.DefaultSlickDatabaseProvider"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem](
-          "akka.persistence.jdbc.journal.JdbcAsyncWriteJournal.slickDb"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem](
-          "akka.persistence.jdbc.snapshot.JdbcSnapshotStore.slickDb")),
-    // special handling as we change organization id
-    mimaPreviousArtifacts := ProjectAutoPlugin.determineMimaPreviousArtifacts(scalaBinaryVersion.value))
+    mimaReportSignatureProblems := true,
+    mimaPreviousArtifacts := Set(
+      organization.value %% name.value % previousStableVersion.value
+        .getOrElse(throw new Error("Unable to determine previous version for MiMa"))
+    ))
 
 lazy val migration = project
   .in(file("migration"))

--- a/core/src/main/mima-filters/4.x.x.backwards.excludes/pr-401-highest-seq-nr.excludes
+++ b/core/src/main/mima-filters/4.x.x.backwards.excludes/pr-401-highest-seq-nr.excludes
@@ -1,0 +1,3 @@
+# https://github.com/akka/akka-persistence-jdbc/pull/401/files
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.jdbc.journal.dao.JournalQueries.highestSequenceNrForPersistenceId")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.jdbc.journal.dao.JournalQueries.highestMarkedSequenceNrForPersistenceId")

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -74,15 +74,4 @@ object ProjectAutoPlugin extends AutoPlugin {
            |""".stripMargin)),
     resolvers += Resolver.typesafeRepo("releases"),
     resolvers += Resolver.jcenterRepo)
-
-  def determineMimaPreviousArtifacts(scalaBinVersion: String): Set[ModuleID] = {
-    val compatVersions: Set[String] =
-      if (scalaBinVersion.startsWith("2.13")) Set("3.5.2")
-      else {
-        Set("3.5.0", "3.5.1", "3.5.2")
-      }
-    compatVersions.map { v =>
-      "com.github.dnvriend" % ("akka-persistence-jdbc_" + scalaBinVersion) % v
-    }
-  }
 }


### PR DESCRIPTION
Use dynver to detect the previous artifact dynamically.

#401 introduced a bin-incompatible change with

```diff
-  private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Query[Rep[Long], Long, Seq] =
-    selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).take(1)
+  private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
+    selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).max

-  private def _highestMarkedSequenceNrForPersistenceId(persistenceId: Rep[String]): Query[Rep[Long], Long, Seq] =
-    selectAllJournalForPersistenceId(persistenceId).filter(_.deleted === true).map(_.sequenceNumber)
+  private def _highestMarkedSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
+    selectAllJournalForPersistenceId(persistenceId).filter(_.deleted === true).map(_.sequenceNumber).max
```

which is exposed in `akka.persistence.jdbc.journal.dao.JournalQueries.highestSequenceNrForPersistenceId` and `akka.persistence.jdbc.journal.dao.JournalQueries.highestMarkedSequenceNrForPersistenceId`.

