### PR TITLE
Make Scalac complain more

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/JournalRow.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/JournalRow.scala
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
- * Copyright (C) 2019 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019 - 2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.jdbc

--- a/core/src/main/scala/akka/persistence/jdbc/JournalRow.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/JournalRow.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.persistence.jdbc
 
 final case class JournalRow(

--- a/core/src/main/scala/akka/persistence/jdbc/JournalRow.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/JournalRow.scala
@@ -1,0 +1,9 @@
+package akka.persistence.jdbc
+
+final case class JournalRow(
+    ordering: Long,
+    deleted: Boolean,
+    persistenceId: String,
+    sequenceNumber: Long,
+    message: Array[Byte],
+    tags: Option[String] = None)

--- a/core/src/main/scala/akka/persistence/jdbc/db/SlickExtension.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/db/SlickExtension.scala
@@ -12,7 +12,6 @@ import com.typesafe.config.{ Config, ConfigObject }
 
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success }
-import scala.util.control.NonFatal
 
 object SlickExtension extends ExtensionId[SlickExtensionImpl] with ExtensionIdProvider {
   override def lookup: SlickExtension.type = SlickExtension

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/BaseJournalDaoWithReadMessages.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/BaseJournalDaoWithReadMessages.scala
@@ -55,7 +55,7 @@ trait BaseJournalDaoWithReadMessages extends JournalDaoWithReadMessages {
                 case Some(lastSeqNr) => lastSeqNr + 1
                 case None            => from
               }
-              Some((nextFrom, nextControl), xs)
+              Some(((nextFrom, nextControl), xs))
             }
           }
 
@@ -67,7 +67,7 @@ trait BaseJournalDaoWithReadMessages extends JournalDaoWithReadMessages {
               akka.pattern.after(delay, scheduler)(retrieveNextBatch())
           }
       }
-      .mapConcat(identity)
+      .mapConcat(identity(_))
   }
 
 }

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/DefaultJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/DefaultJournalDao.scala
@@ -119,7 +119,7 @@ class DefaultJournalDao(
     Source
       .fromPublisher(
         db.stream(
-          queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max)).result))
-      .map(AkkaSerialization.fromRow(serialization))
+          queries.messagesQuery((persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max))).result))
+      .map(AkkaSerialization.fromRow(serialization)(_))
   }
 }

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -5,12 +5,7 @@
 
 package akka.persistence.jdbc.journal.dao.legacy
 
-import akka.persistence.jdbc.journal.dao.{
-  BaseDao,
-  BaseJournalDaoWithReadMessages,
-  H2Compat,
-  JournalDaoWithUpdates
-}
+import akka.persistence.jdbc.journal.dao.{ BaseDao, BaseJournalDaoWithReadMessages, H2Compat, JournalDaoWithUpdates }
 import akka.persistence.jdbc.config.{ BaseDaoConfig, JournalConfig }
 import akka.persistence.jdbc.serialization.FlowPersistentReprSerializer
 import akka.persistence.{ AtomicWrite, PersistentRepr }

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -112,7 +112,8 @@ trait BaseByteArrayJournalDao
       case Success(t) => t
       case Failure(cause) =>
         throw new IllegalArgumentException(
-          s"Failed to serialize ${write.getClass} for update of [$persistenceId] @ [$sequenceNr]", cause)
+          s"Failed to serialize ${write.getClass} for update of [$persistenceId] @ [$sequenceNr]",
+          cause)
     }
     db.run(queries.update(persistenceId, sequenceNr, serializedRow.message).map(_ => Done))
   }

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -110,9 +110,9 @@ trait BaseByteArrayJournalDao
     val write = PersistentRepr(payload, sequenceNr, persistenceId)
     val serializedRow = serializer.serialize(write) match {
       case Success(t) => t
-      case Failure(_) =>
+      case Failure(cause) =>
         throw new IllegalArgumentException(
-          s"Failed to serialize ${write.getClass} for update of [$persistenceId] @ [$sequenceNr]")
+          s"Failed to serialize ${write.getClass} for update of [$persistenceId] @ [$sequenceNr]", cause)
     }
     db.run(queries.update(persistenceId, sequenceNr, serializedRow.message).map(_ => Done))
   }

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -8,10 +8,7 @@ package akka.persistence.jdbc.journal.dao.legacy
 import akka.persistence.jdbc.journal.dao.{
   BaseDao,
   BaseJournalDaoWithReadMessages,
-  FlowControl,
   H2Compat,
-  JournalDao,
-  JournalDaoWithReadMessages,
   JournalDaoWithUpdates
 }
 import akka.persistence.jdbc.config.{ BaseDaoConfig, JournalConfig }
@@ -118,7 +115,7 @@ trait BaseByteArrayJournalDao
     val write = PersistentRepr(payload, sequenceNr, persistenceId)
     val serializedRow = serializer.serialize(write) match {
       case Success(t) => t
-      case Failure(ex) =>
+      case Failure(_) =>
         throw new IllegalArgumentException(
           s"Failed to serialize ${write.getClass} for update of [$persistenceId] @ [$sequenceNr]")
     }
@@ -141,7 +138,7 @@ trait BaseByteArrayJournalDao
     Source
       .fromPublisher(
         db.stream(
-          queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max)).result))
+          queries.messagesQuery((persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max))).result))
       .via(serializer.deserializeFlow)
       .map {
         case Success((repr, _, ordering)) => Success(repr -> ordering)

--- a/core/src/main/scala/akka/persistence/jdbc/query/JournalSequenceActor.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/JournalSequenceActor.scala
@@ -140,10 +140,10 @@ class JournalSequenceActor(readJournalDao: ReadJournalDao, config: JournalSequen
 
     val (nextMax, _, missingElems) =
       // using the ordering elements that were fetched, we verify if there are any gaps
-      elements.foldLeft[(OrderingId, OrderingId, MissingElements)](
+      elements.foldLeft[(OrderingId, OrderingId, MissingElements)]((
         currentMaxOrdering,
         currentMaxOrdering,
-        MissingElements.empty) {
+        MissingElements.empty)) {
         case ((currentMax, previousElement, missing), currentElement) =>
           // we must decide if we move the cursor forward
           val newMax =

--- a/core/src/main/scala/akka/persistence/jdbc/query/JournalSequenceActor.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/JournalSequenceActor.scala
@@ -140,10 +140,8 @@ class JournalSequenceActor(readJournalDao: ReadJournalDao, config: JournalSequen
 
     val (nextMax, _, missingElems) =
       // using the ordering elements that were fetched, we verify if there are any gaps
-      elements.foldLeft[(OrderingId, OrderingId, MissingElements)]((
-        currentMaxOrdering,
-        currentMaxOrdering,
-        MissingElements.empty)) {
+      elements.foldLeft[(OrderingId, OrderingId, MissingElements)](
+        (currentMaxOrdering, currentMaxOrdering, MissingElements.empty)) {
         case ((currentMax, previousElement, missing), currentElement) =>
           // we must decide if we move the cursor forward
           val newMax =

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/DefaultReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/DefaultReadJournalDao.scala
@@ -40,13 +40,13 @@ class DefaultReadJournalDao(
 
     // This doesn't populate the tags. AFAICT they aren't used
     Source
-      .fromPublisher(db.stream(queries.eventsByTag(tag, offset, maxOffset, correctMaxForH2Driver(max)).result))
+      .fromPublisher(db.stream(queries.eventsByTag((tag, offset, maxOffset, correctMaxForH2Driver(max))).result))
       .map(row =>
         AkkaSerialization.fromRow(serialization)(row).map { case (repr, ordering) => (repr, Set.empty, ordering) })
   }
 
   override def journalSequence(offset: Long, limit: Long): Source[Long, NotUsed] =
-    Source.fromPublisher(db.stream(queries.journalSequenceQuery(offset, limit).result))
+    Source.fromPublisher(db.stream(queries.journalSequenceQuery((offset, limit)).result))
 
   override def maxJournalSequence(): Future[Long] =
     db.run(queries.maxJournalSequenceQuery.result)
@@ -59,7 +59,7 @@ class DefaultReadJournalDao(
     Source
       .fromPublisher(
         db.stream(
-          queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max)).result))
-      .map(AkkaSerialization.fromRow(serialization))
+          queries.messagesQuery((persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max))).result))
+      .map(AkkaSerialization.fromRow(serialization)(_))
 
 }

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala
@@ -5,11 +5,7 @@
 
 package akka.persistence.jdbc.query.dao
 
-import akka.persistence.jdbc.config.{
-  EventJournalTableConfiguration,
-  EventTagTableConfiguration,
-  ReadJournalConfig
-}
+import akka.persistence.jdbc.config.{ EventJournalTableConfiguration, EventTagTableConfiguration, ReadJournalConfig }
 import akka.persistence.jdbc.journal.dao.JournalTables
 import slick.jdbc.JdbcProfile
 

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala
@@ -8,7 +8,6 @@ package akka.persistence.jdbc.query.dao
 import akka.persistence.jdbc.config.{
   EventJournalTableConfiguration,
   EventTagTableConfiguration,
-  LegacyJournalTableConfiguration,
   ReadJournalConfig
 }
 import akka.persistence.jdbc.journal.dao.JournalTables

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/legacy/ByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/legacy/ByteArrayReadJournalDao.scala
@@ -41,7 +41,7 @@ trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWith
       maxOffset: Long,
       max: Long): Source[Try[(PersistentRepr, Set[String], Long)], NotUsed] = {
 
-    val publisher = db.stream(queries.eventsByTag(s"%$tag%", offset, maxOffset, correctMaxForH2Driver(max)).result)
+    val publisher = db.stream(queries.eventsByTag((s"%$tag%", offset, maxOffset, correctMaxForH2Driver(max))).result)
     // applies workaround for https://github.com/akka/akka-persistence-jdbc/issues/168
     Source
       .fromPublisher(publisher)
@@ -57,7 +57,7 @@ trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWith
     Source
       .fromPublisher(
         db.stream(
-          queries.messagesQuery(persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max)).result))
+          queries.messagesQuery((persistenceId, fromSequenceNr, toSequenceNr, correctMaxForH2Driver(max))).result))
       .via(serializer.deserializeFlow)
       .map {
         case Success((repr, _, ordering)) => Success(repr -> ordering)
@@ -66,7 +66,7 @@ trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWith
   }
 
   override def journalSequence(offset: Long, limit: Long): Source[Long, NotUsed] =
-    Source.fromPublisher(db.stream(queries.journalSequenceQuery(offset, limit).result))
+    Source.fromPublisher(db.stream(queries.journalSequenceQuery((offset, limit)).result))
 
   override def maxJournalSequence(): Future[Long] = {
     db.run(queries.maxJournalSequenceQuery.result)

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/legacy/ReadJournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/legacy/ReadJournalQueries.scala
@@ -6,7 +6,7 @@
 package akka.persistence.jdbc.query.dao.legacy
 
 import akka.persistence.jdbc.config.{ LegacyJournalTableConfiguration, ReadJournalConfig }
-import akka.persistence.jdbc.journal.dao.legacy.{ JournalRow, JournalTables }
+import akka.persistence.jdbc.journal.dao.legacy.JournalTables
 import slick.jdbc.JdbcProfile
 
 class ReadJournalQueries(val profile: JdbcProfile, val readJournalConfig: ReadJournalConfig) extends JournalTables {

--- a/core/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
@@ -10,7 +10,6 @@ import akka.persistence.jdbc.query.scaladsl.{ JdbcReadJournal => ScalaJdbcReadJo
 import akka.persistence.query.{ EventEnvelope, Offset }
 import akka.persistence.query.javadsl._
 import akka.stream.javadsl.Source
-import akka.persistence.jdbc.util.PluginVersionChecker
 
 object JdbcReadJournal {
   final val Identifier = ScalaJdbcReadJournal.Identifier

--- a/core/src/main/scala/akka/persistence/jdbc/query/package.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/package.scala
@@ -5,10 +5,7 @@
 
 package akka.persistence.jdbc
 
-import akka.NotUsed
 import akka.persistence.query._
-import akka.stream.scaladsl.Source
-import scala.language.implicitConversions
 
 package object query {
   implicit class OffsetOps(val that: Offset) extends AnyVal {

--- a/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -261,7 +261,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
                 // Continue querying from the largest offset
                 xs.map(_.offset.value).max
               }
-              Some((nextStartingOffset, nextControl), xs)
+              Some(((nextStartingOffset, nextControl), xs))
             }
           }
 

--- a/core/src/main/scala/akka/persistence/jdbc/serialization/PersistentReprSerializer.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/serialization/PersistentReprSerializer.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable._
 
 import scala.util.Try
 
-@deprecated(since = "5.0.0")
+@deprecated("use Akka Serialization for the payloads instead", since = "5.0.0")
 trait PersistentReprSerializer[T] {
 
   /**
@@ -45,6 +45,7 @@ trait PersistentReprSerializer[T] {
   def deserialize(t: T): Try[(PersistentRepr, Set[String], Long)]
 }
 
+@deprecated("use Akka Serialization for the payloads instead", since = "5.0.0")
 trait FlowPersistentReprSerializer[T] extends PersistentReprSerializer[T] {
 
   /**

--- a/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/DefaultSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/DefaultSnapshotDao.scala
@@ -83,7 +83,8 @@ class DefaultSnapshotDao(
   override def snapshotForMaxSequenceNr(
       persistenceId: String,
       maxSequenceNr: Long): Future[Option[(SnapshotMetadata, Any)]] =
-    db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr((persistenceId, maxSequenceNr)).result).map(zeroOrOneSnapshot)
+    db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr((persistenceId, maxSequenceNr)).result)
+      .map(zeroOrOneSnapshot)
 
   override def snapshotForMaxSequenceNrAndMaxTimestamp(
       persistenceId: String,
@@ -120,6 +121,8 @@ class DefaultSnapshotDao(
       maxSequenceNr: Long,
       maxTimestamp: Long): Future[Unit] =
     db.run(
-      queries.selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp((persistenceId, maxSequenceNr, maxTimestamp)).delete)
+      queries
+        .selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp((persistenceId, maxSequenceNr, maxTimestamp))
+        .delete)
       .map(_ => ())((ExecutionContexts.parasitic))
 }

--- a/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/DefaultSnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/DefaultSnapshotDao.scala
@@ -78,12 +78,12 @@ class DefaultSnapshotDao(
   override def snapshotForMaxTimestamp(
       persistenceId: String,
       maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] =
-    db.run(queries.selectOneByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).result).map(zeroOrOneSnapshot)
+    db.run(queries.selectOneByPersistenceIdAndMaxTimestamp((persistenceId, maxTimestamp)).result).map(zeroOrOneSnapshot)
 
   override def snapshotForMaxSequenceNr(
       persistenceId: String,
       maxSequenceNr: Long): Future[Option[(SnapshotMetadata, Any)]] =
-    db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).result).map(zeroOrOneSnapshot)
+    db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr((persistenceId, maxSequenceNr)).result).map(zeroOrOneSnapshot)
 
   override def snapshotForMaxSequenceNrAndMaxTimestamp(
       persistenceId: String,
@@ -91,9 +91,9 @@ class DefaultSnapshotDao(
       maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] =
     db.run(
       queries
-        .selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp)
+        .selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp((persistenceId, maxSequenceNr, maxTimestamp))
         .result)
-      .map(zeroOrOneSnapshot)
+      .map(zeroOrOneSnapshot(_))
 
   override def save(snapshotMetadata: SnapshotMetadata, snapshot: Any): Future[Unit] = {
     val eventualSnapshotRow = Future.fromTry(serializeSnapshot(snapshotMetadata, snapshot))
@@ -101,18 +101,18 @@ class DefaultSnapshotDao(
   }
 
   override def delete(persistenceId: String, sequenceNr: Long): Future[Unit] =
-    db.run(queries.selectByPersistenceIdAndSequenceNr(persistenceId, sequenceNr).delete)
+    db.run(queries.selectByPersistenceIdAndSequenceNr((persistenceId, sequenceNr)).delete)
       .map(_ => ())(ExecutionContexts.parasitic)
 
   override def deleteAllSnapshots(persistenceId: String): Future[Unit] =
     db.run(queries.selectAll(persistenceId).delete).map(_ => ())((ExecutionContexts.parasitic))
 
   override def deleteUpToMaxSequenceNr(persistenceId: String, maxSequenceNr: Long): Future[Unit] =
-    db.run(queries.selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).delete)
+    db.run(queries.selectByPersistenceIdUpToMaxSequenceNr((persistenceId, maxSequenceNr)).delete)
       .map(_ => ())((ExecutionContexts.parasitic))
 
   override def deleteUpToMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Unit] =
-    db.run(queries.selectByPersistenceIdUpToMaxTimestamp(persistenceId, maxTimestamp).delete)
+    db.run(queries.selectByPersistenceIdUpToMaxTimestamp((persistenceId, maxTimestamp)).delete)
       .map(_ => ())((ExecutionContexts.parasitic))
 
   override def deleteUpToMaxSequenceNrAndMaxTimestamp(
@@ -120,6 +120,6 @@ class DefaultSnapshotDao(
       maxSequenceNr: Long,
       maxTimestamp: Long): Future[Unit] =
     db.run(
-      queries.selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp).delete)
+      queries.selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp((persistenceId, maxSequenceNr, maxTimestamp)).delete)
       .map(_ => ())((ExecutionContexts.parasitic))
 }

--- a/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotQueries.scala
@@ -5,7 +5,7 @@
 
 package akka.persistence.jdbc.snapshot.dao
 
-import akka.persistence.jdbc.config.{ LegacySnapshotTableConfiguration, SnapshotTableConfiguration }
+import akka.persistence.jdbc.config.SnapshotTableConfiguration
 import akka.persistence.jdbc.snapshot.dao.SnapshotTables.SnapshotRow
 import slick.jdbc.JdbcProfile
 

--- a/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
@@ -5,7 +5,7 @@
 
 package akka.persistence.jdbc.snapshot.dao
 
-import akka.persistence.jdbc.config.{ LegacySnapshotTableConfiguration, SnapshotTableConfiguration }
+import akka.persistence.jdbc.config.SnapshotTableConfiguration
 import akka.persistence.jdbc.snapshot.dao.SnapshotTables.SnapshotRow
 import akka.persistence.jdbc.snapshot.dao.legacy.SnapshotTables.isOracleDriver
 import akka.persistence.jdbc.util.InputStreamOps.InputStreamImplicits

--- a/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/legacy/ByteArraySnapshotDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/legacy/ByteArraySnapshotDao.scala
@@ -43,14 +43,14 @@ class ByteArraySnapshotDao(
       persistenceId: String,
       maxTimestamp: Long): Future[Option[(SnapshotMetadata, Any)]] =
     for {
-      rows <- db.run(queries.selectOneByPersistenceIdAndMaxTimestamp(persistenceId, maxTimestamp).result)
+      rows <- db.run(queries.selectOneByPersistenceIdAndMaxTimestamp((persistenceId, maxTimestamp)).result)
     } yield rows.headOption.map(toSnapshotData)
 
   override def snapshotForMaxSequenceNr(
       persistenceId: String,
       maxSequenceNr: Long): Future[Option[(SnapshotMetadata, Any)]] =
     for {
-      rows <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr(persistenceId, maxSequenceNr).result)
+      rows <- db.run(queries.selectOneByPersistenceIdAndMaxSequenceNr((persistenceId, maxSequenceNr)).result)
     } yield rows.headOption.map(toSnapshotData)
 
   override def snapshotForMaxSequenceNrAndMaxTimestamp(
@@ -60,7 +60,7 @@ class ByteArraySnapshotDao(
     for {
       rows <- db.run(
         queries
-          .selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp)
+          .selectOneByPersistenceIdAndMaxSequenceNrAndMaxTimestamp((persistenceId, maxSequenceNr, maxTimestamp))
           .result)
     } yield rows.headOption.map(toSnapshotData)
 
@@ -71,7 +71,7 @@ class ByteArraySnapshotDao(
 
   override def delete(persistenceId: String, sequenceNr: Long): Future[Unit] =
     for {
-      _ <- db.run(queries.selectByPersistenceIdAndSequenceNr(persistenceId, sequenceNr).delete)
+      _ <- db.run(queries.selectByPersistenceIdAndSequenceNr((persistenceId, sequenceNr)).delete)
     } yield ()
 
   override def deleteAllSnapshots(persistenceId: String): Future[Unit] =
@@ -81,12 +81,12 @@ class ByteArraySnapshotDao(
 
   override def deleteUpToMaxSequenceNr(persistenceId: String, maxSequenceNr: Long): Future[Unit] =
     for {
-      _ <- db.run(queries.selectByPersistenceIdUpToMaxSequenceNr(persistenceId, maxSequenceNr).delete)
+      _ <- db.run(queries.selectByPersistenceIdUpToMaxSequenceNr((persistenceId, maxSequenceNr)).delete)
     } yield ()
 
   override def deleteUpToMaxTimestamp(persistenceId: String, maxTimestamp: Long): Future[Unit] =
     for {
-      _ <- db.run(queries.selectByPersistenceIdUpToMaxTimestamp(persistenceId, maxTimestamp).delete)
+      _ <- db.run(queries.selectByPersistenceIdUpToMaxTimestamp((persistenceId, maxTimestamp)).delete)
     } yield ()
 
   override def deleteUpToMaxSequenceNrAndMaxTimestamp(
@@ -96,7 +96,7 @@ class ByteArraySnapshotDao(
     for {
       _ <- db.run(
         queries
-          .selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp(persistenceId, maxSequenceNr, maxTimestamp)
+          .selectByPersistenceIdUpToMaxSequenceNrAndMaxTimestamp((persistenceId, maxSequenceNr, maxTimestamp))
           .delete)
     } yield ()
 }

--- a/core/src/main/scala/akka/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/testkit/internal/SchemaUtilsImpl.scala
@@ -9,7 +9,7 @@ import java.sql.Statement
 
 import scala.concurrent.Future
 import akka.Done
-import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
+import akka.actor.ClassicActorSystemProvider
 import akka.annotation.InternalApi
 import akka.dispatch.Dispatchers
 import akka.persistence.jdbc.db.SlickDatabase

--- a/core/src/test/java/akka/persistence/jdbc/JavadslSnippets.java
+++ b/core/src/test/java/akka/persistence/jdbc/JavadslSnippets.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.persistence.jdbc;
 
 import akka.Done;

--- a/core/src/test/scala/akka/persistence/jdbc/ScaladslSnippets.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/ScaladslSnippets.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.persistence.jdbc
 
 import akka.{ Done, NotUsed }

--- a/core/src/test/scala/akka/persistence/jdbc/SingleActorSystemPerTestSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/SingleActorSystemPerTestSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem
 import akka.persistence.jdbc.config.{ JournalConfig, ReadJournalConfig, SlickConfiguration }
 import akka.persistence.jdbc.query.javadsl.JdbcReadJournal
 import akka.persistence.jdbc.util.DropCreate
-import akka.persistence.jdbc.db.{ SlickDatabase, SlickDriver }
+import akka.persistence.jdbc.db.SlickDatabase
 import akka.util.Timeout
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValue }
 import org.scalatest.BeforeAndAfterEach

--- a/core/src/test/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializerTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/journal/dao/ByteArrayJournalSerializerTest.scala
@@ -7,7 +7,6 @@ package akka.persistence.jdbc
 package journal.dao.legacy
 
 import akka.persistence.{ AtomicWrite, PersistentRepr }
-import akka.serialization.SerializationExtension
 
 import scala.collection.immutable._
 

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
@@ -17,7 +17,7 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
 
   it should "find events from sequenceNr" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors() { (actor1, _, _) =>
       actor1 ! 1
       actor1 ! 2
       actor1 ! 3
@@ -35,49 +35,49 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
         tp.expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 1, 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2, timestamp = 0L))
         tp.expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2, timestamp = 0L))
         tp.expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3, timestamp = 0L))
         tp.expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3, timestamp = 0L))
         tp.expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 0, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3, timestamp = 0L))
         tp.expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 1, 3) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3, timestamp = 0L))
         tp.expectComplete()
       }
     }
@@ -141,7 +141,7 @@ abstract class CurrentEventsByPersistenceIdTest(config: String) extends QueryTes
 
   it should "find events for actors" in withActorSystem { implicit system =>
     val journalOps = new JavaDslJdbcReadJournalOperations(system)
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors() { (actor1, _, _) =>
       actor1 ! 1
       actor1 ! 2
       actor1 ! 3

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -110,15 +110,21 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1"), timestamp = 0L)).expectComplete()
+        tp.request(Int.MaxValue)
+          .expectNext(EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1"), timestamp = 0L))
+          .expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2"), timestamp = 0L)).expectComplete()
+        tp.request(Int.MaxValue)
+          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2"), timestamp = 0L))
+          .expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(3), "my-1", 3, EventRestored("3"), timestamp = 0L)).expectComplete()
+        tp.request(Int.MaxValue)
+          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, EventRestored("3"), timestamp = 0L))
+          .expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -56,17 +56,17 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
 
   it should "apply event adapter when querying events for actor with pid 'my-1'" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors() { (actor1, _, _) =>
       journalOps.withEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(10)
         tp.expectNoMessage(100.millis)
 
         actor1 ! Event("1")
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1")))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1"), timestamp = 0L))
         tp.expectNoMessage(100.millis)
 
         actor1 ! Event("2")
-        tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2")))
+        tp.expectNext(ExpectNextTimeout, EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2"), timestamp = 0L))
         tp.expectNoMessage(100.millis)
         tp.cancel()
       }
@@ -86,12 +86,12 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
 
       journalOps.withEventsByTag(10.seconds)("event", Sequence(1)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, EventRestored("2")))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, EventRestored("3")))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, EventRestored("2"), timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, EventRestored("3"), timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
 
         actor1 ? TaggedEvent(Event("1"), "event")
-        tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, EventRestored("1")))
+        tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, EventRestored("1"), timestamp = 0L))
         tp.cancel()
         tp.expectNoMessage(NoMsgTime)
       }
@@ -100,7 +100,7 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
 
   it should "apply event adapters when querying current events for actors" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors() { (actor1, _, _) =>
       actor1 ! Event("1")
       actor1 ! Event("2")
       actor1 ! Event("3")
@@ -110,21 +110,21 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 1, 1) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1"))).expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(1), "my-1", 1, EventRestored("1"), timestamp = 0L)).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 2) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2"))).expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2"), timestamp = 0L)).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 3, 3) { tp =>
-        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(3), "my-1", 3, EventRestored("3"))).expectComplete()
+        tp.request(Int.MaxValue).expectNext(EventEnvelope(Sequence(3), "my-1", 3, EventRestored("3"), timestamp = 0L)).expectComplete()
       }
 
       journalOps.withCurrentEventsByPersistenceId()("my-1", 2, 3) { tp =>
         tp.request(Int.MaxValue)
-          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2")))
-          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, EventRestored("3")))
+          .expectNext(EventEnvelope(Sequence(2), "my-1", 2, EventRestored("2"), timestamp = 0L))
+          .expectNext(EventEnvelope(Sequence(3), "my-1", 3, EventRestored("3"), timestamp = 0L))
           .expectComplete()
       }
     }

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -29,7 +29,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
   it should "find events from sequenceNr" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors() { (actor1, _, _) =>
       actor1 ! withTags(1, "number")
       actor1 ! withTags(2, "number")
       actor1 ! withTags(3, "number")
@@ -216,7 +216,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
   it should "find events for actor with pid 'my-1'" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors() { (actor1, _, _) =>
       journalOps.withEventsByPersistenceId()("my-1", 0) { tp =>
         tp.request(10)
         tp.expectNoMessage(100.millis)
@@ -236,7 +236,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
   it should "find events for actor with pid 'my-1' and persisting messages to other actor" in withActorSystem {
     implicit system =>
       val journalOps = new JavaDslJdbcReadJournalOperations(system)
-      withTestActors() { (actor1, actor2, actor3) =>
+      withTestActors() { (actor1, actor2, _) =>
         journalOps.withEventsByPersistenceId()("my-1", 0, Long.MaxValue) { tp =>
           tp.request(10)
           tp.expectNoMessage(100.millis)
@@ -266,7 +266,7 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
   it should "find events for actor with pid 'my-2'" in withActorSystem { implicit system =>
     val journalOps = new JavaDslJdbcReadJournalOperations(system)
-    withTestActors() { (actor1, actor2, actor3) =>
+    withTestActors() { (_, actor2, _) =>
       actor2 ! 1
       actor2 ! 2
       actor2 ! 3

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -56,38 +56,38 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
       journalOps.withEventsByTag()("number", Sequence(Long.MinValue)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("number", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("number", Sequence(0)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("number", Sequence(1)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("number", Sequence(2)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.cancel()
       }
 
@@ -100,19 +100,19 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
       journalOps.withEventsByTag()("number", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
 
         actor1 ? withTags(1, "number")
-        tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, 1))
+        tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, 1, timestamp = 0L))
 
         actor1 ? withTags(1, "number")
-        tp.expectNext(EventEnvelope(Sequence(5), "my-1", 3, 1))
+        tp.expectNext(EventEnvelope(Sequence(5), "my-1", 3, 1, timestamp = 0L))
 
         actor1 ? withTags(1, "number")
-        tp.expectNext(EventEnvelope(Sequence(6), "my-1", 4, 1))
+        tp.expectNext(EventEnvelope(Sequence(6), "my-1", 4, 1, timestamp = 0L))
         tp.cancel()
         tp.expectNoMessage(NoMsgTime)
       }
@@ -166,29 +166,29 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
       journalOps.withEventsByTag()("number", Sequence(Long.MinValue)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("sharded-1", Sequence(Long.MinValue)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("sharded-10", Sequence(Long.MinValue)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       journalOps.withEventsByTag()("sharded-100", Sequence(Long.MinValue)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
@@ -238,12 +238,12 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
       journalOps.withEventsByTag()("number", Sequence(1)) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 3, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
 
         actor1 ? withTags(1, "number")
-        tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, 1))
+        tp.expectNext(EventEnvelope(Sequence(4), "my-1", 2, 1, timestamp = 0L))
         tp.cancel()
         tp.expectNoMessage(NoMsgTime)
       }
@@ -258,15 +258,15 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.expectNoMessage(NoMsgTime)
 
         actor1 ! withTags(1, "one") // 1
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
 
         actor2 ! withTags(1, "one") // 2
-        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 1))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-2", 1, 1, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
 
         actor3 ! withTags(1, "one") // 3
-        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 1))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-3", 1, 1, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
 
         actor1 ! withTags(2, "two") // 4
@@ -279,15 +279,15 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
         tp.expectNoMessage(NoMsgTime)
 
         actor1 ! withTags(1, "one") // 7
-        tp.expectNext(EventEnvelope(Sequence(7), "my-1", 3, 1))
+        tp.expectNext(EventEnvelope(Sequence(7), "my-1", 3, 1, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
 
         actor2 ! withTags(1, "one") // 8
-        tp.expectNext(EventEnvelope(Sequence(8), "my-2", 3, 1))
+        tp.expectNext(EventEnvelope(Sequence(8), "my-2", 3, 1, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
 
         actor3 ! withTags(1, "one") // 9
-        tp.expectNext(EventEnvelope(Sequence(9), "my-3", 3, 1))
+        tp.expectNext(EventEnvelope(Sequence(9), "my-3", 3, 1, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
         tp.expectNoMessage(NoMsgTime)
@@ -318,37 +318,37 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
       journalOps.withEventsByTag(10.seconds)("prime", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
-        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2))
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
-        tp.expectNext(EventEnvelope(Sequence(5), "my-1", 5, 5))
-        tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3))
-        tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(2), "my-1", 2, 2, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(5), "my-1", 5, 5, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       journalOps.withEventsByTag(10.seconds)("three", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
-        tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3))
-        tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       journalOps.withEventsByTag(10.seconds)("3", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3))
-        tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3))
-        tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3))
+        tp.expectNext(EventEnvelope(Sequence(3), "my-1", 3, 3, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(6), "my-2", 1, 3, timestamp = 0L))
+        tp.expectNext(EventEnvelope(Sequence(7), "my-3", 1, 3, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
 
       journalOps.withEventsByTag(10.seconds)("one", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1))
+        tp.expectNext(EventEnvelope(Sequence(1), "my-1", 1, 1, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
       }
@@ -362,7 +362,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
       journalOps.withEventsByTag(10.seconds)("five", NoOffset) { tp =>
         tp.request(Int.MaxValue)
-        tp.expectNext(EventEnvelope(Sequence(5), "my-1", 5, 5))
+        tp.expectNext(EventEnvelope(Sequence(5), "my-1", 5, 5, timestamp = 0L))
         tp.expectNoMessage(NoMsgTime)
         tp.cancel()
         tp.expectNoMessage(NoMsgTime)

--- a/core/src/test/scala/akka/persistence/jdbc/query/HardDeleteQueryTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/HardDeleteQueryTest.scala
@@ -5,10 +5,8 @@
 
 package akka.persistence.jdbc.query
 
-import akka.persistence.query.{ EventEnvelope, NoOffset, Sequence }
+import akka.persistence.query.NoOffset
 import akka.pattern._
-import com.typesafe.config.ConfigFactory
-import org.scalactic.source.Position
 
 import scala.concurrent.duration._
 import org.scalatest.matchers.should.Matchers

--- a/core/src/test/scala/akka/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
@@ -43,8 +43,6 @@ abstract class JournalDaoStreamMessagesMemoryTest(configFile: String)
   val journalSequenceActorConfig = readJournalConfig.journalSequenceRetrievalConfiguration
   val journalTableCfg = journalConfig.journalTableConfiguration
 
-  import profile.api._
-
   implicit val askTimeout = 50.millis
 
   def generateId: Int = 0

--- a/core/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/JournalSequenceActorTest.scala
@@ -184,7 +184,7 @@ class MockDaoJournalSequenceActorTest extends SharedActorSystemTestSpec {
 
     val almostQueryDelay = queryDelay - 50.millis
     val almostImmediately = 50.millis
-    withTestProbeJournalSequenceActor(batchSize, maxTries, queryDelay) { (daoProbe, actor) =>
+    withTestProbeJournalSequenceActor(batchSize, maxTries, queryDelay) { (daoProbe, _) =>
       daoProbe.expectMsg(almostImmediately, TestProbeReadJournalDao.JournalSequence(0, batchSize))
       val firstBatch = (1L to 40L) ++ (51L to 110L)
       daoProbe.reply(firstBatch)

--- a/core/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -20,7 +20,6 @@ import akka.stream.testkit.javadsl.{ TestSink => JavaSink }
 import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.{ Materializer, SystemMaterializer }
 import com.typesafe.config.ConfigValue
-import slick.jdbc.PostgresProfile.api._
 import scala.concurrent.Future
 import scala.concurrent.duration.{ FiniteDuration, _ }
 
@@ -28,7 +27,6 @@ import akka.persistence.jdbc.testkit.internal.H2
 import akka.persistence.jdbc.testkit.internal.MySQL
 import akka.persistence.jdbc.testkit.internal.Oracle
 import akka.persistence.jdbc.testkit.internal.Postgres
-import akka.persistence.jdbc.testkit.internal.SchemaUtilsImpl
 import akka.persistence.jdbc.testkit.internal.SqlServer
 
 trait ReadJournalOperations {
@@ -242,7 +240,7 @@ abstract class QueryTestSpec(config: String, configOverrides: Map[String, Config
           }
 
         case event @ Tagged(payload: Int, tags) =>
-          persist(event) { (event: Tagged) =>
+          persist(event) { _ =>
             updateState(payload)
             if (replyToMessages) sender() ! akka.actor.Status.Success((payload, tags))
           }
@@ -252,11 +250,11 @@ abstract class QueryTestSpec(config: String, configOverrides: Map[String, Config
           }
 
         case event @ TaggedEvent(payload: Event, tag) =>
-          persist(event) { evt =>
+          persist(event) { _ =>
             if (replyToMessages) sender() ! akka.actor.Status.Success((payload, tag))
           }
         case event @ TaggedAsyncEvent(payload: Event, tag) =>
-          persistAsync(event) { evt =>
+          persistAsync(event) { _ =>
             if (replyToMessages) sender() ! akka.actor.Status.Success((payload, tag))
           }
       }

--- a/core/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
@@ -72,7 +72,7 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
     }
 
     // the recover cycle
-    withActor("1") { actor => recover => failure => rejected =>
+    withActor("1") { _ => recover => failure => rejected =>
       recover.expectMsg("foo")
       recover.expectMsg(RecoveryCompleted)
       failure.expectNoMessage(100.millis)
@@ -82,7 +82,7 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
 
   it should "not persist a single non-serializable message" in {
     class NotSerializable
-    withActor("2") { actor => recover => failure => rejected =>
+    withActor("2") { actor => recover => _ => rejected =>
       val tp = TestProbe()
       recover.expectMsg(RecoveryCompleted)
       tp.send(actor, new NotSerializable) // the NotSerializable class cannot be serialized
@@ -94,7 +94,7 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
     }
 
     // the recover cycle, no message should be recovered
-    withActor("2") { actor => recover => failure => rejected =>
+    withActor("2") { _ => recover => _ => _ =>
       recover.expectMsg(RecoveryCompleted)
       recover.expectNoMessage(100.millis)
     }
@@ -102,7 +102,7 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
 
   it should "persist only serializable messages" in {
     class NotSerializable
-    withActor("3") { actor => recover => failure => rejected =>
+    withActor("3") { actor => recover => _ => rejected =>
       val tp = TestProbe()
       recover.expectMsg(RecoveryCompleted)
       tp.send(actor, "foo")
@@ -117,7 +117,7 @@ abstract class StoreOnlySerializableMessagesTest(config: String, schemaType: Sch
     }
 
     // recover cycle
-    withActor("3") { actor => recover => failure => rejected =>
+    withActor("3") { _ => recover => failure => rejected =>
       recover.expectMsg("foo")
       recover.expectMsg(RecoveryCompleted)
       failure.expectNoMessage(100.millis)

--- a/migration/src/test/scala/akka/persistence/jdbc/migration/PostgresSpec.scala
+++ b/migration/src/test/scala/akka/persistence/jdbc/migration/PostgresSpec.scala
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
- * Copyright (C) 2019 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019 - 2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.jdbc.migration

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -46,19 +46,19 @@ object ProjectAutoPlugin extends AutoPlugin {
         "-language:implicitConversions",
         "-target:jvm-1.8"),
     Compile / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 13)) =>
-        disciplineScalacOptions -- Set(
-          "-Ywarn-inaccessible",
-          "-Ywarn-infer-any",
-          "-Ywarn-nullary-override",
-          "-Ywarn-nullary-unit",
-          "-Ypartial-unification",
-          "-Yno-adapted-args")
-      case Some((2, 12)) =>
-        disciplineScalacOptions
-      case _ =>
-        Nil
-    }).toSeq,
+        case Some((2, 13)) =>
+          disciplineScalacOptions -- Set(
+            "-Ywarn-inaccessible",
+            "-Ywarn-infer-any",
+            "-Ywarn-nullary-override",
+            "-Ywarn-nullary-unit",
+            "-Ypartial-unification",
+            "-Yno-adapted-args")
+        case Some((2, 12)) =>
+          disciplineScalacOptions
+        case _ =>
+          Nil
+      }).toSeq,
     scalacOptions += "-Ydelambdafy:method",
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
         "-doc-title",

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -40,17 +40,25 @@ object ProjectAutoPlugin extends AutoPlugin {
     scalacOptions ++= Seq(
         "-encoding",
         "UTF-8",
-        "-deprecation",
-        "-feature",
         "-unchecked",
         "-Xlog-reflective-calls",
         "-language:higherKinds",
         "-language:implicitConversions",
         "-target:jvm-1.8"),
-    scalacOptions += {
-      if (scalaVersion.value.startsWith("2.13")) ""
-      else "-Ypartial-unification"
-    },
+    Compile / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 13)) =>
+        disciplineScalacOptions -- Set(
+          "-Ywarn-inaccessible",
+          "-Ywarn-infer-any",
+          "-Ywarn-nullary-override",
+          "-Ywarn-nullary-unit",
+          "-Ypartial-unification",
+          "-Yno-adapted-args")
+      case Some((2, 12)) =>
+        disciplineScalacOptions
+      case _ =>
+        Nil
+    }).toSeq,
     scalacOptions += "-Ydelambdafy:method",
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
         "-doc-title",
@@ -74,4 +82,20 @@ object ProjectAutoPlugin extends AutoPlugin {
            |""".stripMargin)),
     resolvers += Resolver.typesafeRepo("releases"),
     resolvers += Resolver.jcenterRepo)
+
+  val disciplineScalacOptions = Set(
+//    "-Xfatal-warnings",
+    "-feature",
+    "-Yno-adapted-args",
+    "-deprecation",
+    "-Xlint",
+    "-Ywarn-dead-code",
+    "-Ywarn-inaccessible",
+    "-Ywarn-infer-any",
+    "-Ywarn-nullary-override",
+    "-Ywarn-nullary-unit",
+    "-Ywarn-unused:_",
+    "-Ypartial-unification",
+    "-Ywarn-extra-implicit")
+
 }


### PR DESCRIPTION
Not all the way to fatal warnings, but most warnings are fixed.
I didn't want to bring in the Silencer in this round.

- enable more compiler warnings
- fix most compiler warnings

References #473
