### PR TITLE
Use section akka.persistence.jdbc (instead of akka-persistence-jdbc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.com/akka/akka-persistence-jdbc.svg?branch=master)](https://travis-ci.com/github/akka/akka-persistence-jdbc)
 [![License](https://img.shields.io/:license-Apache%202-red.svg)](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-akka-persistence-jdbc writes journal and snapshot entries to a configured JDBC store. It implements the full akka-persistence-query API and is therefore very useful for implementing DDD-style 
+Akka Persistence JDBC writes journal and snapshot entries to a configured JDBC store. It implements the full akka-persistence-query API and is therefore very useful for implementing DDD-style 
 application models using Akka for creating reactive applications.
 
 ## Documentation

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-akka-persistence-jdbc {
+akka.persistence.jdbc {
 
   # If set to true event deletion is performed as a soft, logical delete. Events are kept in the journal and are sill
   # delivered in queries. Otherwise, a hard delete will be performed. 
@@ -168,10 +168,10 @@ jdbc-journal {
   }
 
   # The tag separator to use when tagging events with more than one tag.
-  # should not be configured directly, but through property akka-persistence-jdbc.tagSeparator
+  # should not be configured directly, but through property akka.persistence.jdbc.tagSeparator
   # in order to keep consistent behavior over write/read sides
   # Only used for the legacy schema
-  tagSeparator = ${akka-persistence-jdbc.tagSeparator}
+  tagSeparator = ${akka.persistence.jdbc.tagSeparator}
 
   # If you have data from pre 5.0.0 use the legacy akka.persistence.jdbc.journal.dao.legacy.ByteArrayJournalDao
   # Dao. Migration to the new dao will be added in the future.
@@ -189,16 +189,16 @@ jdbc-journal {
   parallelism = 8
 
   # Only mark as deleted. If false, delete physically
-  # should not be configured directly, but through property akka-persistence-jdbc.logicalDelete.enable
+  # should not be configured directly, but through property akka.persistence.jdbc.logicalDelete.enable
   # in order to keep consistent behavior over write/read sides
-  logicalDelete = ${akka-persistence-jdbc.logicalDeletion.enable}
+  logicalDelete = ${akka.persistence.jdbc.logicalDeletion.enable}
 
   # This setting can be used to configure usage of a shared database.
   # To disable usage of a shared database, set to null or an empty string.
   # When set to a non emty string, this setting does two things:
   # - The actor which manages the write-journal will not automatically close the db when the actor stops (since it is shared)
-  # - If akka-persistence-jdbc.database-provider-fqcn is set to akka.persistence.jdbc.db.DefaultSlickDatabaseProvider
-  #   then the shared database with the given name will be used. (shared databases are configured as part of akka-persistence-jdbc.shared-databases)
+  # - If akka.persistence.jdbc.database-provider-fqcn is set to akka.persistence.jdbc.db.DefaultSlickDatabaseProvider
+  #   then the shared database with the given name will be used. (shared databases are configured as part of akka.persistence.jdbc.shared-databases)
   #   Please note that the database will only be shared with the other journals if the use-shared-db is also set
   #   to the same value for these other journals.
   use-shared-db = null
@@ -318,8 +318,8 @@ jdbc-snapshot-store {
   # To disable usage of a shared database, set to null or an empty string.
   # When set to a non emty string, this setting does two things:
   # - The actor which manages the snapshot-journal will not automatically close the db when the actor stops (since it is shared)
-  # - If akka-persistence-jdbc.database-provider-fqcn is set to akka.persistence.jdbc.db.DefaultSlickDatabaseProvider
-  #   then the shared database with the given name will be used. (shared databases are configured as part of akka-persistence-jdbc.shared-databases)
+  # - If akka.persistence.jdbc.database-provider-fqcn is set to akka.persistence.jdbc.db.DefaultSlickDatabaseProvider
+  #   then the shared database with the given name will be used. (shared databases are configured as part of akka.persistence.jdbc.shared-databases)
   #   Please note that the database will only be shared with the other journals if the use-shared-db is also set
   #   to the same value for these other journals.
   use-shared-db = null
@@ -423,9 +423,9 @@ jdbc-read-journal {
 
   # This setting can be used to configure usage of a shared database.
   # To disable usage of a shared database, set to null or an empty string.
-  # This setting only has effect if akka-persistence-jdbc.database-provider-fqcn is set to
+  # This setting only has effect if akka.persistence.jdbc.database-provider-fqcn is set to
   # akka.persistence.jdbc.db.DefaultSlickDatabaseProvider. When this setting is set to a non empty string
-  # then the shared database with the given name will be used. (shared databases are configured as part of akka-persistence-jdbc.shared-databases)
+  # then the shared database with the given name will be used. (shared databases are configured as part of akka.persistence.jdbc.shared-databases)
   # Please note that the database will only be shared with the other journals if the use-shared-db is also set
   # to the same value for these other journals.
   use-shared-db = null
@@ -433,9 +433,9 @@ jdbc-read-journal {
   dao = "akka.persistence.jdbc.query.dao.DefaultReadJournalDao"
 
   # if true, queries will include logically deleted events
-  # should not be configured directly, but through property akka-persistence-jdbc.logicalDelete.enable
+  # should not be configured directly, but through property akka.persistence.jdbc.logicalDelete.enable
   # in order to keep consistent behavior over write/read sides
-  includeLogicallyDeleted = ${akka-persistence-jdbc.logicalDeletion.enable}
+  includeLogicallyDeleted = ${akka.persistence.jdbc.logicalDeletion.enable}
 
   # Settings for determining if ids (ordering column) in the journal are out of sequence.
   journal-sequence-retrieval {
@@ -462,9 +462,9 @@ jdbc-read-journal {
   }
 
   # The tag separator to use when tagging events with more than one tag.
-  # should not be configured directly, but through property akka-persistence-jdbc.tagSeparator
+  # should not be configured directly, but through property akka.persistence.jdbc.tagSeparator
   # in order to keep consistent behavior over write/read sides
-  tagSeparator = ${akka-persistence-jdbc.tagSeparator}
+  tagSeparator = ${akka.persistence.jdbc.tagSeparator}
 
   slick {
 

--- a/core/src/main/scala/akka/persistence/jdbc/db/SlickExtension.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/db/SlickExtension.scala
@@ -21,7 +21,7 @@ object SlickExtension extends ExtensionId[SlickExtensionImpl] with ExtensionIdPr
 class SlickExtensionImpl(system: ExtendedActorSystem) extends Extension {
 
   private val dbProvider: SlickDatabaseProvider = {
-    val fqcn = system.settings.config.getString("akka-persistence-jdbc.database-provider-fqcn")
+    val fqcn = system.settings.config.getString("akka.persistence.jdbc.database-provider-fqcn")
     val args = List(classOf[ActorSystem] -> system)
     system.dynamicAccess.createInstanceFor[SlickDatabaseProvider](fqcn, args) match {
       case Success(result) => result
@@ -54,7 +54,7 @@ trait SlickDatabaseProvider {
 
 class DefaultSlickDatabaseProvider(system: ActorSystem) extends SlickDatabaseProvider {
   val sharedDatabases: Map[String, LazySlickDatabase] = system.settings.config
-    .getObject("akka-persistence-jdbc.shared-databases")
+    .getObject("akka.persistence.jdbc.shared-databases")
     .asScala
     .flatMap {
       case (key, confObj: ConfigObject) =>
@@ -65,7 +65,7 @@ class DefaultSlickDatabaseProvider(system: ActorSystem) extends SlickDatabasePro
         } else Nil
       case (key, notAnObject) =>
         throw new RuntimeException(
-          s"""Expected "akka-persistence-jdbc.shared-databases.$key" to be a config ConfigObject, but got ${notAnObject
+          s"""Expected "akka.persistence.jdbc.shared-databases.$key" to be a config ConfigObject, but got ${notAnObject
             .valueType()} (${notAnObject.getClass})""")
     }
     .toMap
@@ -74,7 +74,7 @@ class DefaultSlickDatabaseProvider(system: ActorSystem) extends SlickDatabasePro
     sharedDatabases.getOrElse(
       sharedDbName,
       throw new RuntimeException(
-        s"No shared database is configured under akka-persistence-jdbc.shared-databases.$sharedDbName"))
+        s"No shared database is configured under akka.persistence.jdbc.shared-databases.$sharedDbName"))
 
   def database(config: Config): SlickDatabase = {
     config.asOptionalNonEmptyString(ConfigKeys.useSharedDb) match {

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -59,8 +59,8 @@ trait BaseByteArrayJournalDao
   // Therefore, we make sure we only log a warning for logical deletes once
   lazy val logWarnAboutLogicalDeletionDeprecation = {
     logger.warn(
-      "Logical deletion of events is deprecated and will be removed in akka-persistence-jdbc in a later version " +
-      "To disable it in this current version you must set the property 'akka-persistence-jdbc.logicalDeletion.enable' to false.")
+      "Logical deletion of events is deprecated and will be removed in akka.persistence.jdbc in a later version " +
+      "To disable it in this current version you must set the property 'akka.persistence.jdbc.logicalDeletion.enable' to false.")
   }
 
   def writeJournalRows(xs: Seq[JournalRow]): Future[Unit] = { // Write atomically without auto-commit

--- a/core/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
@@ -108,7 +108,7 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal)
    * The offset is exclusive, i.e. the event corresponding to the given `offset` parameter is not
    * included in the stream.
    *
-   * For akka-persistence-jdbc the `offset` corresponds to the `ordering` column in the Journal table.
+   * For Akka Persistence JDBC the `offset` corresponds to the `ordering` column in the Journal table.
    * The `ordering` is a sequential id number that uniquely identifies the position of each event within
    * the event stream. The `Offset` type is `akka.persistence.query.Sequence` with the `ordering` as the
    * offset value.

--- a/core/src/main/scala/akka/persistence/jdbc/query/package.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/package.scala
@@ -15,7 +15,7 @@ package object query {
         case NoOffset              => 0L
         case _ =>
           throw new IllegalArgumentException(
-            "akka-persistence-jdbc does not support " + that.getClass.getName + " offsets")
+            "Akka Persistence JDBC does not support " + that.getClass.getName + " offsets")
       }
   }
 }

--- a/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -288,7 +288,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
    * The offset is exclusive, i.e. the event corresponding to the given `offset` parameter is not
    * included in the stream.
    *
-   * For akka-persistence-jdbc the `offset` corresponds to the `ordering` column in the Journal table.
+   * For Akka Persistence JDBC the `offset` corresponds to the `ordering` column in the Journal table.
    * The `ordering` is a sequential id number that uniquely identifies the position of each event within
    * the event stream. The `Offset` type is `akka.persistence.query.Sequence` with the `ordering` as the
    * offset value.

--- a/core/src/main/scala/akka/persistence/jdbc/testkit/javadsl/SchemaUtils.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/testkit/javadsl/SchemaUtils.scala
@@ -29,7 +29,7 @@ object SchemaUtils {
    * For production, it's recommended to run any DDL statements before the system is started.
    *
    * This method will automatically detects the configured database using the settings from `jdbc-journal` config.
-   * If configured with `use-shared-db`, it will use the `akka-persistence-jdbc.shared-databases` definition instead.
+   * If configured with `use-shared-db`, it will use the `akka.persistence.jdbc.shared-databases` definition instead.
    * See https://doc.akka.io/docs/akka-persistence-jdbc/current/index.html#sharing-the-database-connection-pool-between-the-journals for details.
    */
   @ApiMayChange
@@ -46,7 +46,7 @@ object SchemaUtils {
    * For production, it's recommended to create run DDL statements before the system is started.
    *
    * This method will automatically detects the configured database using the settings from `jdbc-journal` config.
-   * If configured with `use-shared-db`, it will use the `akka-persistence-jdbc.shared-databases` definition instead.
+   * If configured with `use-shared-db`, it will use the `akka.persistence.jdbc.shared-databases` definition instead.
    * See https://doc.akka.io/docs/akka-persistence-jdbc/current/index.html#sharing-the-database-connection-pool-between-the-journals for details.
    */
   @ApiMayChange
@@ -59,7 +59,7 @@ object SchemaUtils {
    * This utility method is intended to be used for testing only.
    * For production, it's recommended to run any DDL statements before the system is started.
    *
-   * It will use the database settings found under `jdbc-journal`, or `akka-persistence-jdbc.shared-databases` if configured so.
+   * It will use the database settings found under `jdbc-journal`, or `akka.persistence.jdbc.shared-databases` if configured so.
    * See https://doc.akka.io/docs/akka-persistence-jdbc/current/index.html#sharing-the-database-connection-pool-between-the-journals for details.
    *
    * @param script the DDL script. The passed script can contain more then one SQL statements separated by a ; (semi-colon).
@@ -74,7 +74,7 @@ object SchemaUtils {
    * This utility method is intended to be used for testing only.
    * For production, it's recommended to run any DDL statements before the system is started.
    *
-   * It will use the database settings found under `configKey`, or `akka-persistence-jdbc.shared-databases` if configured so.
+   * It will use the database settings found under `configKey`, or `akka.persistence.jdbc.shared-databases` if configured so.
    * See https://doc.akka.io/docs/akka-persistence-jdbc/current/index.html#sharing-the-database-connection-pool-between-the-journals for details.
    *
    * @param script the DDL script. The passed `script` can contain more then one SQL statements.

--- a/core/src/main/scala/akka/persistence/jdbc/testkit/scaladsl/SchemaUtils.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/testkit/scaladsl/SchemaUtils.scala
@@ -27,7 +27,7 @@ object SchemaUtils {
    * For production, it's recommended to run any DDL statements before the system is started.
    *
    * This method will automatically detects the configured database using the settings from `jdbc-journal` config.
-   * If configured with `use-shared-db`, it will use the `akka-persistence-jdbc.shared-databases` definition instead.
+   * If configured with `use-shared-db`, it will use the `akka.persistence.jdbc.shared-databases` definition instead.
    * See https://doc.akka.io/docs/akka-persistence-jdbc/current/index.html#sharing-the-database-connection-pool-between-the-journals for details.
    */
   @ApiMayChange
@@ -44,7 +44,7 @@ object SchemaUtils {
    * For production, it's recommended to run any DDL statements before the system is started.
    *
    * This method will automatically detects the configured database using the settings from `jdbc-journal` config.
-   * If configured with `use-shared-db`, it will use the `akka-persistence-jdbc.shared-databases` definition instead.
+   * If configured with `use-shared-db`, it will use the `akka.persistence.jdbc.shared-databases` definition instead.
    * See https://doc.akka.io/docs/akka-persistence-jdbc/current/index.html#sharing-the-database-connection-pool-between-the-journals for details.
    */
   @ApiMayChange
@@ -57,7 +57,7 @@ object SchemaUtils {
    * This utility method is intended to be used for testing only.
    * For production, it's recommended to run any DDL statements before the system is started.
    *
-   * It will use the database settings found under `jdbc-journal`, or `akka-persistence-jdbc.shared-databases` if configured so.
+   * It will use the database settings found under `jdbc-journal`, or `akka.persistence.jdbc.shared-databases` if configured so.
    * See https://doc.akka.io/docs/akka-persistence-jdbc/current/index.html#sharing-the-database-connection-pool-between-the-journals for details.
    *
    * @param script the DDL script. The passed script can contain more then one SQL statements separated by a ; (semi-colon).
@@ -72,7 +72,7 @@ object SchemaUtils {
    * This utility method is intended to be used for testing only.
    * For production, it's recommended to create the table with DDL statements before the system is started.
    *
-   * It will use the database settings found under `configKey`, or `akka-persistence-jdbc.shared-databases` if configured so.
+   * It will use the database settings found under `configKey`, or `akka.persistence.jdbc.shared-databases` if configured so.
    * See https://doc.akka.io/docs/akka-persistence-jdbc/current/index.html#sharing-the-database-connection-pool-between-the-journals for details.
    *
    * @param script the DDL script. The passed `script` can contain more then one SQL statements.

--- a/core/src/test/resources/general.conf
+++ b/core/src/test/resources/general.conf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// This file contains the general settings which are shared in all akka-persistence-jdbc tests
+// This file contains the general settings which are shared in all Akka Persistence JDBC tests
 
 akka {
   stdout-loglevel = off // defaults to WARNING can be disabled with off. The stdout-loglevel is only in effect during system startup and shutdown
@@ -43,7 +43,7 @@ docker {
 }
 
 jdbc-journal {
-  logicalDelete = ${akka-persistence-jdbc.logicalDeletion.enable}
+  logicalDelete = ${akka.persistence.jdbc.logicalDeletion.enable}
   event-adapters {
     test-write-event-adapter = "akka.persistence.jdbc.query.EventAdapterTest$TestWriteEventAdapter"
     test-read-event-adapter  = "akka.persistence.jdbc.query.EventAdapterTest$TestReadEventAdapter"
@@ -59,7 +59,7 @@ jdbc-journal {
 
 
 jdbc-read-journal {
-  includeLogicallyDeleted = ${akka-persistence-jdbc.logicalDeletion.enable}
+  includeLogicallyDeleted = ${akka.persistence.jdbc.logicalDeletion.enable}
   refresh-interval = "10ms"
   max-buffer-size = "500"
 }

--- a/core/src/test/resources/h2-application-with-hard-delete.conf
+++ b/core/src/test/resources/h2-application-with-hard-delete.conf
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 include "h2-application.conf"
 
-akka-persistence-jdbc.logicalDeletion.enable = false
+akka.persistence.jdbc.logicalDeletion.enable = false

--- a/core/src/test/resources/h2-application.conf
+++ b/core/src/test/resources/h2-application.conf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 
 akka {

--- a/core/src/test/resources/h2-shared-db-application.conf
+++ b/core/src/test/resources/h2-shared-db-application.conf
@@ -26,21 +26,20 @@ akka {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
-  }
-}
-
-akka-persistence-jdbc {
-  shared-databases {
-    slick {
-      profile = "slick.jdbc.H2Profile$"
-      db {
-        url = "jdbc:h2:mem:test-database;DATABASE_TO_UPPER=false;"
-        user = "root"
-        password = "root"
-        driver = "org.h2.Driver"
-        numThreads = 5
-        maxConnections = 5
-        minConnections = 1
+    jdbc {
+      shared-databases {
+        slick {
+          profile = "slick.jdbc.H2Profile$"
+          db {
+            url = "jdbc:h2:mem:test-database;DATABASE_TO_UPPER=false;"
+            user = "root"
+            password = "root"
+            driver = "org.h2.Driver"
+            numThreads = 5
+            maxConnections = 5
+            minConnections = 1
+          }
+        }
       }
     }
   }

--- a/core/src/test/resources/jndi-application.conf
+++ b/core/src/test/resources/jndi-application.conf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 
 akka {

--- a/core/src/test/resources/jndi-shared-db-application.conf
+++ b/core/src/test/resources/jndi-shared-db-application.conf
@@ -26,14 +26,13 @@ akka {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
-  }
-}
-
-akka-persistence-jdbc {
-  shared-databases {
-    slick {
-      profile = "slick.jdbc.PostgresProfile$"
-      jndiName = "java:/jboss/datasources/bla"
+    jdbc {
+      shared-databases {
+        slick {
+          profile = "slick.jdbc.PostgresProfile$"
+          jndiName = "java:/jboss/datasources/bla"
+        }
+      }
     }
   }
 }

--- a/core/src/test/resources/mysql-application-with-hard-delete.conf
+++ b/core/src/test/resources/mysql-application-with-hard-delete.conf
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 include "mysql-application.conf"
 
-akka-persistence-jdbc.logicalDeletion.enable = false
+akka.persistence.jdbc.logicalDeletion.enable = false

--- a/core/src/test/resources/mysql-application.conf
+++ b/core/src/test/resources/mysql-application.conf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 
 akka {

--- a/core/src/test/resources/mysql-shared-db-application.conf
+++ b/core/src/test/resources/mysql-shared-db-application.conf
@@ -26,23 +26,22 @@ akka {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
-  }
-}
-
-akka-persistence-jdbc {
-  shared-databases {
-    slick {
-      profile = "slick.jdbc.MySQLProfile$"
-      db {
-        host = ${docker.host}
-        host = ${?DB_HOST}
-        url = "jdbc:mysql://"${akka-persistence-jdbc.shared-databases.slick.db.host}":3306/mysql?cachePrepStmts=true&cacheCallableStmts=true&cacheServerConfiguration=true&useLocalSessionState=true&elideSetAutoCommits=true&alwaysSendSetIsolation=false&enableQueryTimeouts=false&connectionAttributes=none&verifyServerCertificate=false&useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&useLegacyDatetimeCode=false&serverTimezone=UTC&rewriteBatchedStatements=true"
-        user = "root"
-        password = "root"
-        driver = "com.mysql.cj.jdbc.Driver"
-        numThreads = 5
-        maxConnections = 5
-        minConnections = 1
+    jdbc {
+      shared-databases {
+        slick {
+          profile = "slick.jdbc.MySQLProfile$"
+          db {
+            host = ${docker.host}
+            host = ${?DB_HOST}
+            url = "jdbc:mysql://"${akka.persistence.jdbc.shared-databases.slick.db.host}":3306/mysql?cachePrepStmts=true&cacheCallableStmts=true&cacheServerConfiguration=true&useLocalSessionState=true&elideSetAutoCommits=true&alwaysSendSetIsolation=false&enableQueryTimeouts=false&connectionAttributes=none&verifyServerCertificate=false&useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&useLegacyDatetimeCode=false&serverTimezone=UTC&rewriteBatchedStatements=true"
+            user = "root"
+            password = "root"
+            driver = "com.mysql.cj.jdbc.Driver"
+            numThreads = 5
+            maxConnections = 5
+            minConnections = 1
+          }
+        }
       }
     }
   }

--- a/core/src/test/resources/oracle-application-with-hard-delete.conf
+++ b/core/src/test/resources/oracle-application-with-hard-delete.conf
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 include "oracle-application.conf"
 
-akka-persistence-jdbc.logicalDeletion.enable = false
+akka.persistence.jdbc.logicalDeletion.enable = false

--- a/core/src/test/resources/oracle-application.conf
+++ b/core/src/test/resources/oracle-application.conf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 include "oracle-schema-overrides.conf"
 

--- a/core/src/test/resources/oracle-shared-db-application.conf
+++ b/core/src/test/resources/oracle-shared-db-application.conf
@@ -27,27 +27,27 @@ akka {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
-  }
-}
-
-akka-persistence-jdbc {
-  shared-databases {
-    slick {
-      profile = "slick.jdbc.OracleProfile$"
-      db {
-        host = ${docker.host}
-        host = ${?DB_HOST}
-        url = "jdbc:oracle:thin:@//"${akka-persistence-jdbc.shared-databases.slick.db.host}":1521/xe"
-        user = "system"
-        password = "oracle"
-        driver = "oracle.jdbc.OracleDriver"
-        numThreads = 5
-        maxConnections = 5
-        minConnections = 1
+    jdbc {
+      shared-databases {
+        slick {
+          profile = "slick.jdbc.OracleProfile$"
+          db {
+            host = ${docker.host}
+            host = ${?DB_HOST}
+            url = "jdbc:oracle:thin:@//"${akka.persistence.jdbc.shared-databases.slick.db.host}":1521/xe"
+            user = "system"
+            password = "oracle"
+            driver = "oracle.jdbc.OracleDriver"
+            numThreads = 5
+            maxConnections = 5
+            minConnections = 1
+          }
+        }
       }
     }
   }
 }
+
 
 jdbc-journal {
   use-shared-db = "slick"

--- a/core/src/test/resources/postgres-application-with-hard-delete.conf
+++ b/core/src/test/resources/postgres-application-with-hard-delete.conf
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 include "postgres-application.conf"
 
-akka-persistence-jdbc.logicalDeletion.enable = false
+akka.persistence.jdbc.logicalDeletion.enable = false

--- a/core/src/test/resources/postgres-application.conf
+++ b/core/src/test/resources/postgres-application.conf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 
 akka {

--- a/core/src/test/resources/postgres-shared-db-application.conf
+++ b/core/src/test/resources/postgres-shared-db-application.conf
@@ -26,23 +26,22 @@ akka {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
-  }
-}
-
-akka-persistence-jdbc {
-  shared-databases {
-    slick {
-      profile = "slick.jdbc.PostgresProfile$"
-      db {
-        host = "localhost"
-        host = ${?DB_HOST}
-        url = "jdbc:postgresql://"${akka-persistence-jdbc.shared-databases.slick.db.host}":5432/docker?reWriteBatchedInserts=true"
-        user = "docker"
-        password = "docker"
-        driver = "org.postgresql.Driver"
-        numThreads = 5
-        maxConnections = 5
-        minConnections = 1
+    jdbc {
+      shared-databases {
+        slick {
+          profile = "slick.jdbc.PostgresProfile$"
+          db {
+            host = "localhost"
+            host = ${?DB_HOST}
+            url = "jdbc:postgresql://"${akka.persistence.jdbc.shared-databases.slick.db.host}":5432/docker?reWriteBatchedInserts=true"
+            user = "docker"
+            password = "docker"
+            driver = "org.postgresql.Driver"
+            numThreads = 5
+            maxConnections = 5
+            minConnections = 1
+          }
+        }
       }
     }
   }

--- a/core/src/test/resources/sqlserver-application-with-hard-delete.conf
+++ b/core/src/test/resources/sqlserver-application-with-hard-delete.conf
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// general.conf is included only for shared settings used for the akka-persistence-jdbc tests
+// general.conf is included only for shared settings used for the Akka Persistence JDBC tests
 include "general.conf"
 include "sqlserver-application.conf"
 
-akka-persistence-jdbc.logicalDeletion.enable = false
+akka.persistence.jdbc.logicalDeletion.enable = false

--- a/core/src/test/resources/sqlserver-shared-db-application.conf
+++ b/core/src/test/resources/sqlserver-shared-db-application.conf
@@ -26,23 +26,22 @@ akka {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
-  }
-}
-
-akka-persistence-jdbc {
-  shared-databases {
-    slick {
-      profile = "slick.jdbc.SQLServerProfile$"
-      db {
-        host = ${docker.host}
-        host = ${?DB_HOST}
-        url = "jdbc:sqlserver://"${akka-persistence-jdbc.shared-databases.slick.db.host}":1433;databaseName=docker;integratedSecurity=false;"
-        user = "docker"
-        password = "docker"
-        driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
-        numThreads = 5
-        maxConnections = 5
-        minConnections = 1
+    jdbc {
+      shared-databases {
+        slick {
+          profile = "slick.jdbc.SQLServerProfile$"
+          db {
+            host = ${docker.host}
+            host = ${?DB_HOST}
+            url = "jdbc:sqlserver://"${akka.persistence.jdbc.shared-databases.slick.db.host}":1433;databaseName=docker;integratedSecurity=false;"
+            user = "docker"
+            password = "docker"
+            driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+            numThreads = 5
+            maxConnections = 5
+            minConnections = 1
+          }
+        }
       }
     }
   }

--- a/core/src/test/scala/akka/persistence/jdbc/SingleActorSystemPerTestSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/SingleActorSystemPerTestSpec.scala
@@ -40,7 +40,7 @@ abstract class SingleActorSystemPerTestSpec(val config: Config)
     else List(journalConfig.journalTableConfiguration.tableName)
   val profile = if (cfg.hasPath("slick.profile")) {
     SlickDatabase.profile(cfg, "slick")
-  } else SlickDatabase.profile(config, "akka-persistence-jdbc.shared-databases.slick")
+  } else SlickDatabase.profile(config, "akka.persistence.jdbc.shared-databases.slick")
   val readJournalConfig = new ReadJournalConfig(config.getConfig(JdbcReadJournal.Identifier))
 
   // The db is initialized in the before and after each bocks
@@ -52,8 +52,8 @@ abstract class SingleActorSystemPerTestSpec(val config: Config)
       } else
         SlickDatabase.database(
           config,
-          new SlickConfiguration(config.getConfig("akka-persistence-jdbc.shared-databases.slick")),
-          "akka-persistence-jdbc.shared-databases.slick.db")
+          new SlickConfiguration(config.getConfig("akka.persistence.jdbc.shared-databases.slick")),
+          "akka.persistence.jdbc.shared-databases.slick.db")
 
       dbOpt = Some(newDb)
       newDb

--- a/core/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/TablesTestSpec.scala
@@ -55,7 +55,7 @@ abstract class TablesTestSpec extends AnyFlatSpec with Matchers {
       |      port = ${?POSTGRES_PORT}
       |      name = "docker"
       |
-      |      url = "jdbc:postgresql://"${akka-persistence-jdbc.slick.db.host}":"${akka-persistence-jdbc.slick.db.port}"/"${akka-persistence-jdbc.slick.db.name}
+      |      url = "jdbc:postgresql://"${akka.persistence.jdbc.slick.db.host}":"${akka.persistence.jdbc.slick.db.port}"/"${akka.persistence.jdbc.slick.db.name}
       |      user = "docker"
       |      password = "docker"
       |      driver = "org.postgresql.Driver"
@@ -115,7 +115,7 @@ abstract class TablesTestSpec extends AnyFlatSpec with Matchers {
       |      port = ${?POSTGRES_PORT}
       |      name = "docker"
       |
-      |      url = "jdbc:postgresql://"${akka-persistence-jdbc.slick.db.host}":"${akka-persistence-jdbc.slick.db.port}"/"${akka-persistence-jdbc.slick.db.name}
+      |      url = "jdbc:postgresql://"${akka.persistence.jdbc.slick.db.host}":"${akka.persistence.jdbc.slick.db.port}"/"${akka.persistence.jdbc.slick.db.name}
       |      user = "docker"
       |      password = "docker"
       |      driver = "org.postgresql.Driver"
@@ -185,7 +185,7 @@ abstract class TablesTestSpec extends AnyFlatSpec with Matchers {
       |      port = ${?POSTGRES_PORT}
       |      name = "docker"
       |
-      |      url = "jdbc:postgresql://"${akka-persistence-jdbc.slick.db.host}":"${akka-persistence-jdbc.slick.db.port}"/"${akka-persistence-jdbc.slick.db.name}
+      |      url = "jdbc:postgresql://"${akka.persistence.jdbc.slick.db.host}":"${akka.persistence.jdbc.slick.db.port}"/"${akka.persistence.jdbc.slick.db.name}
       |      user = "docker"
       |      password = "docker"
       |      driver = "org.postgresql.Driver"

--- a/core/src/test/scala/akka/persistence/jdbc/configuration/AkkaPersistenceConfigTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/configuration/AkkaPersistenceConfigTest.scala
@@ -47,7 +47,7 @@ class AkkaPersistenceConfigTest extends AnyFlatSpec with Matchers {
       |      port = ${?POSTGRES_PORT}
       |      name = "docker"
       |
-      |      url = "jdbc:postgresql://"${akka-persistence-jdbc.slick.db.host}":"${akka-persistence-jdbc.slick.db.port}"/"${akka-persistence-jdbc.slick.db.name}
+      |      url = "jdbc:postgresql://"${akka.persistence.jdbc.slick.db.host}":"${akka.persistence.jdbc.slick.db.port}"/"${akka.persistence.jdbc.slick.db.name}
       |      user = "docker"
       |      password = "docker"
       |      driver = "org.postgresql.Driver$"
@@ -105,7 +105,7 @@ class AkkaPersistenceConfigTest extends AnyFlatSpec with Matchers {
       |      port = ${?POSTGRES_PORT}
       |      name = "docker"
       |
-      |      url = "jdbc:postgresql://"${akka-persistence-jdbc.slick.db.host}":"${akka-persistence-jdbc.slick.db.port}"/"${akka-persistence-jdbc.slick.db.name}
+      |      url = "jdbc:postgresql://"${akka.persistence.jdbc.slick.db.host}":"${akka.persistence.jdbc.slick.db.port}"/"${akka.persistence.jdbc.slick.db.name}
       |      user = "docker"
       |      password = "docker"
       |      driver = "org.postgresql.Driver"
@@ -174,7 +174,7 @@ class AkkaPersistenceConfigTest extends AnyFlatSpec with Matchers {
       |      port = ${?POSTGRES_PORT}
       |      name = "docker"
       |
-      |      url = "jdbc:postgresql://"${akka-persistence-jdbc.slick.db.host}":"${akka-persistence-jdbc.slick.db.port}"/"${akka-persistence-jdbc.slick.db.name}
+      |      url = "jdbc:postgresql://"${akka.persistence.jdbc.slick.db.host}":"${akka.persistence.jdbc.slick.db.port}"/"${akka.persistence.jdbc.slick.db.name}
       |      user = "docker"
       |      password = "docker"
       |      driver = "org.postgresql.Driver"

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -41,7 +41,7 @@ A `dropIfExists` variant is also available.
 
 ## Reference Configuration
 
-akka-persistence-jdbc provides the defaults as part of the @extref:[reference.conf](github:/core/src/main/resources/reference.conf). This file documents all the values which can be configured.
+Akka Persistence JDBC provides the defaults as part of the @extref:[reference.conf](github:/core/src/main/resources/reference.conf). This file documents all the values which can be configured.
 
 There are several possible ways to configure loading your database connections. Options will be explained below.
 
@@ -96,7 +96,7 @@ needs to be configured in the application.conf. In addition, you might want to c
 the database to be closed automatically:
 
 ```hocon
-akka-persistence-jdbc {
+akka.persistence.jdbc {
   database-provider-fqcn = "com.mypackage.CustomSlickDatabaseProvider"
 }
 jdbc-journal {
@@ -125,7 +125,7 @@ jdbc-journal {
 When using the `use-shared-db = slick` setting, the follow configuration can serve as an example:
 
 ```hocon
-akka-persistence-jdbc {
+akka.persistence.jdbc {
   shared-databases {
     slick {
       profile = "slick.jdbc.PostgresProfile$"

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -2,7 +2,7 @@
 
 The Akka Persistence JDBC plugin allows for using JDBC-compliant databases as backend for @extref:[Akka Persistence](akka:persistence.html) and @extref:[Akka Persistence Query](akka:persistence-query.html).
 
-akka-persistence-jdbc writes journal and snapshot entries to a configured JDBC store. It implements the full akka-persistence-query API and is therefore very useful for implementing DDD-style application models using Akka and Scala for creating reactive applications.
+Akka Persistence JDBC writes journal and snapshot entries to a configured JDBC store. It implements the full akka-persistence-query API and is therefore very useful for implementing DDD-style application models using Akka and Scala for creating reactive applications.
 
 Akka Persistence JDBC requires Akka $akka.version$ or later. It uses extref:[Slick](slick:) $slick.version$ internally to access the database via JDBC, this does not require user code to make use of Slick.
 

--- a/migration/src/main/resources/reference.conf
+++ b/migration/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-akka-persistence-jdbc {
+akka.persistence.jdbc {
   migration {
     # supported values: postgres
     database-vendor = ""

--- a/migration/src/main/scala/akka/persistence/jdbc/migration/Main.scala
+++ b/migration/src/main/scala/akka/persistence/jdbc/migration/Main.scala
@@ -11,7 +11,7 @@ import org.flywaydb.core.api.Location
 
 object Main extends App {
 
-  val config = ConfigFactory.load().getConfig("akka-persistence-jdbc.migration")
+  val config = ConfigFactory.load().getConfig("akka.persistence.jdbc.migration")
 
   def run(config: Config): Unit = {
     val vendor = config.getString("database-vendor")


### PR DESCRIPTION
It is an anomaly of this plugin to read settings from the root config section `akka-persistence-jdbc` where it should have been a subsection as `akka.persistence.jdbc`.

As version 5.0 breaks the database schema which will make it unlikely for users to migrate from earlier versions, changing the config structure could be an option.
