### PR TITLE
Better SchemaUtils and Data Migration tool

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val `akka-persistence-jdbc` = project
   .in(file("."))
   .enablePlugins(ScalaUnidocPlugin)
   .disablePlugins(MimaPlugin, SitePlugin)
-  .aggregate(core, migration, docs)
+  .aggregate(core, migration, docs, `schema-utils`)
   .settings(publish / skip := true)
 
 lazy val core = project
@@ -29,6 +29,16 @@ lazy val migration = project
     name := "akka-persistence-jdbc-migration",
     libraryDependencies ++= Dependencies.Migration,
     publish / skip := true)
+
+lazy val `schema-utils` = project
+  .in(file("schema-utils"))
+  .enablePlugins(Publish)
+  .disablePlugins(SitePlugin, MimaPlugin)
+  .settings(
+    name := "akka-persistence-jdbc-schema-utils",
+    libraryDependencies ++= Dependencies.Migration ++ Dependencies.Libraries,
+    publish / skip := true)
+  .dependsOn(core)
 
 lazy val docs = project
   .enablePlugins(ProjectAutoPlugin, AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "org.scalatest" %% "scalatest" % ScalaTestVersion % Test) ++ JdbcDrivers.map(_ % Test)
 
   val Migration: Seq[ModuleID] = Seq(
-    "org.flywaydb" % "flyway-core" % "7.5.1",
+    "org.flywaydb" % "flyway-core" % "7.5.2",
     "com.typesafe" % "config" % "1.4.1",
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "org.testcontainers" % "postgresql" % "1.15.1" % Test,

--- a/schema-utils/src/main/resources/db/migration/postgres/V1__create-table.sql
+++ b/schema-utils/src/main/resources/db/migration/postgres/V1__create-table.sql
@@ -1,0 +1,56 @@
+-- creation of the new akka persistence jdbc schemas
+
+-- event_journal table
+CREATE TABLE IF NOT EXISTS ${apj:event_journal}
+(
+    ordering           BIGSERIAL,
+    persistence_id     VARCHAR(255)          NOT NULL,
+    sequence_number    BIGINT                NOT NULL,
+    deleted            BOOLEAN DEFAULT FALSE NOT NULL,
+
+    writer             VARCHAR(255)          NOT NULL,
+    write_timestamp    BIGINT,
+    adapter_manifest   VARCHAR(255),
+
+    event_ser_id       INTEGER               NOT NULL,
+    event_ser_manifest VARCHAR(255)          NOT NULL,
+    event_payload      BYTEA                 NOT NULL,
+
+    meta_ser_id        INTEGER,
+    meta_ser_manifest  VARCHAR(255),
+    meta_payload       BYTEA,
+
+    PRIMARY KEY (persistence_id, sequence_number)
+);
+
+CREATE UNIQUE INDEX ${apj:event_journal}_ordering_idx ON ${apj:event_journal} (ordering);
+
+-- event_tag table
+CREATE TABLE IF NOT EXISTS ${apj:event_tag}
+(
+    event_id BIGINT,
+    tag      VARCHAR(256),
+    PRIMARY KEY (event_id, tag),
+    CONSTRAINT fk_${apj:event_journal}
+        FOREIGN KEY (event_id)
+            REFERENCES ${apj:event_journal} (ordering)
+            ON DELETE CASCADE
+);
+
+-- state_snapshot table
+CREATE TABLE IF NOT EXISTS ${apj:state_snapshot}
+(
+    persistence_id        VARCHAR(255) NOT NULL,
+    sequence_number       BIGINT       NOT NULL,
+    created               BIGINT       NOT NULL,
+
+    snapshot_ser_id       INTEGER      NOT NULL,
+    snapshot_ser_manifest VARCHAR(255) NOT NULL,
+    snapshot_payload      BYTEA        NOT NULL,
+
+    meta_ser_id           INTEGER,
+    meta_ser_manifest     VARCHAR(255),
+    meta_payload          BYTEA,
+
+    PRIMARY KEY (persistence_id, sequence_number)
+);

--- a/schema-utils/src/main/scala/akka/persistence/jdbc/tools/LegacyJournalDataMigrator.scala
+++ b/schema-utils/src/main/scala/akka/persistence/jdbc/tools/LegacyJournalDataMigrator.scala
@@ -1,0 +1,62 @@
+package akka.persistence.jdbc.tools
+
+import akka.actor.ActorSystem
+import akka.persistence.journal.EventAdapter
+import akka.persistence.{ AtomicWrite, Persistence, PersistentRepr }
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.NotUsed
+import com.typesafe.config.Config
+
+import scala.collection.immutable
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+import scala.util.Try
+
+/**
+ * helps migrate all events in the legacy journal to the new journal
+ *
+ * @param config
+ * @param system
+ */
+final case class LegacyJournalDataMigrator(config: Config)(implicit system: ActorSystem) {
+  import system.dispatcher
+
+  private val storesConfig = StoresConfig(config)
+  private val daos = MigrationDaos(storesConfig)
+
+  private val eventAdapters = Persistence(system).adaptersFor("", config)
+
+  private def adaptEvents(repr: PersistentRepr): Seq[PersistentRepr] = {
+    val adapter: EventAdapter = eventAdapters.get(repr.payload.getClass)
+    adapter.fromJournal(repr.payload, repr.manifest).events.map(repr.withPayload)
+  }
+
+  /**
+   * reads all the current events in the legacy journal
+   *
+   * @return the source of all the events
+   */
+  def readEvents(): Source[PersistentRepr, NotUsed] = {
+    daos.legacyReadJournalDao
+      .allPersistenceIdsSource(Long.MaxValue)
+      .flatMapConcat((persistenceId: String) => {
+        daos.legacyReadJournalDao
+          .messagesWithBatch(persistenceId, 0L, Long.MaxValue, storesConfig.readJournalConfig.maxBufferSize, None)
+          .mapAsync(1)(reprAndOrdNr => Future.fromTry(reprAndOrdNr))
+          .mapConcat { case (repr, _) =>
+            adaptEvents(repr)
+          }
+      })
+  }
+
+  /**
+   * write all legacy events into the new journal tables applying the proper serialization
+   */
+  def writeEvents(): Future[Future[Seq[Try[Unit]]]] = {
+    readEvents()
+      .runWith(Sink.seq) // TODO: find the best way to load all the events in memory
+      .map((sq: Seq[PersistentRepr]) => {
+        daos.defaultJournalDao.asyncWriteMessages(immutable.Seq(AtomicWrite(sq)))
+      })
+  }
+}

--- a/schema-utils/src/main/scala/akka/persistence/jdbc/tools/MigrationDaos.scala
+++ b/schema-utils/src/main/scala/akka/persistence/jdbc/tools/MigrationDaos.scala
@@ -1,0 +1,47 @@
+package akka.persistence.jdbc.tools
+
+import akka.actor.ActorSystem
+import akka.persistence.jdbc.db.SlickExtension
+import akka.persistence.jdbc.journal.dao.DefaultJournalDao
+import akka.persistence.jdbc.query.dao.legacy.ByteArrayReadJournalDao
+import akka.persistence.jdbc.snapshot.dao.DefaultSnapshotDao
+import akka.persistence.jdbc.snapshot.dao.legacy.ByteArraySnapshotDao
+import akka.serialization.SerializationExtension
+import slick.basic.DatabaseConfig
+import slick.jdbc
+import slick.jdbc.{ JdbcBackend, JdbcProfile }
+
+/**
+ * Wrapper class defining the various DAOs that are needed to run journal data migration
+ *
+ * @param storesConfig the stores config
+ * @param system the actor system
+ */
+final case class MigrationDaos(storesConfig: StoresConfig)(implicit system: ActorSystem) {
+  import system.dispatcher
+
+  // get an instance of the database and the Jdbc profile
+  val profile: JdbcProfile = DatabaseConfig.forConfig[JdbcProfile]("slick").profile
+
+  val journaldb: JdbcBackend.Database =
+    SlickExtension(system).database(storesConfig.config.getConfig("jdbc-read-journal")).database
+  val snapshotdb: jdbc.JdbcBackend.Database =
+    SlickExtension(system).database(storesConfig.config.getConfig("jdbc-snapshot-store")).database
+
+  // get an instance of the legacy read journal dao
+  val legacyReadJournalDao: ByteArrayReadJournalDao =
+    new ByteArrayReadJournalDao(journaldb, profile, storesConfig.readJournalConfig, SerializationExtension(system))
+
+  // get an instance of the default journal dao
+  val defaultJournalDao: DefaultJournalDao =
+    new DefaultJournalDao(journaldb, profile, storesConfig.journalConfig, SerializationExtension(system))
+
+  // get the instance of the legacy snapshot dao
+  val legacySnapshotDao: ByteArraySnapshotDao =
+    new ByteArraySnapshotDao(snapshotdb, profile, storesConfig.snapshotConfig, SerializationExtension(system))
+
+  // get the instance if the default snapshot dao
+  val defaultSnapshotDao: DefaultSnapshotDao =
+    new DefaultSnapshotDao(snapshotdb, profile, storesConfig.snapshotConfig, SerializationExtension(system))
+
+}

--- a/schema-utils/src/main/scala/akka/persistence/jdbc/tools/SchemasUtil.scala
+++ b/schema-utils/src/main/scala/akka/persistence/jdbc/tools/SchemasUtil.scala
@@ -1,0 +1,60 @@
+package akka.persistence.jdbc.tools
+
+import com.typesafe.config.Config
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.Location
+import org.flywaydb.core.api.configuration.FluentConfiguration
+import org.flywaydb.core.api.output.MigrateResult
+
+import scala.jdk.CollectionConverters.{ CollectionHasAsScala, MapHasAsJava }
+
+/**
+ * executes the database migration
+ *
+ * @param config the application config
+ */
+final case class SchemasUtil(config: Config) {
+  private val userKey: String = "jdbc-journal.slick.db.user"
+  private val passwordKey: String = "jdbc-journal.slick.db.password"
+  private val urlKey: String = "jdbc-journal.slick.db.url"
+
+  // Flyway placeholders values keys
+  private val eventJournalPlaceholderValueKey: String = "jdbc-journal.tables.event_journal.tableName"
+  private val eventTagPlaceholderValueKey: String = "jdbc-journal.tables.event_tag.tableName"
+  private val stateSnapshotPlaceholderValueKey: String = "jdbc-snapshot-store.tables.snapshot.tableName"
+
+  // Flyway placeholders
+  private val eventJournalPlaceholder = "apj:event_journal"
+  private val eventTagPlaceholder: String = "apj:event_tag"
+  private val stateSnapshotPlaceholder: String = "apj:state_snapshot"
+
+  private val url: String = config.getString(urlKey)
+  private val user: String = config.getString(userKey)
+  private val password: String = config.getString(passwordKey)
+
+  /**
+   * create the persistence schemas.
+   *
+   * @return the list of migration versions run
+   */
+  def run(): Seq[String] = {
+    val flywayConfig: FluentConfiguration = Flyway.configure
+      .dataSource(url, user, password)
+      .table("apj_schema_history")
+      .locations(new Location("classpath:db/migration/postgres"))
+      .ignoreMissingMigrations(true) // in case someone has some missing migrations
+      .placeholders(Map(
+        eventJournalPlaceholder -> config.getString(eventJournalPlaceholderValueKey),
+        eventTagPlaceholder -> config.getString(eventTagPlaceholderValueKey),
+        stateSnapshotPlaceholder -> config.getString(stateSnapshotPlaceholderValueKey)).asJava)
+
+    val flyway: Flyway = flywayConfig.load
+    flyway.baseline()
+    // running the migration
+    val result: MigrateResult = flyway.migrate()
+
+    // let us return the sequence of migration versions applied sorted in a descending order
+    result.migrations.asScala.toSeq.map(_.version).sortWith(_ > _)
+  }
+
+}

--- a/schema-utils/src/main/scala/akka/persistence/jdbc/tools/StoresConfig.scala
+++ b/schema-utils/src/main/scala/akka/persistence/jdbc/tools/StoresConfig.scala
@@ -1,0 +1,10 @@
+package akka.persistence.jdbc.tools
+
+import akka.persistence.jdbc.config.{ JournalConfig, ReadJournalConfig, SnapshotConfig }
+import com.typesafe.config.Config
+
+final case class StoresConfig(config: Config) {
+  val journalConfig = new JournalConfig(config.getConfig("jdbc-journal"))
+  val snapshotConfig = new SnapshotConfig(config.getConfig("jdbc-snapshot-store"))
+  val readJournalConfig = new ReadJournalConfig(config.getConfig("jdbc-read-journal"))
+}


### PR DESCRIPTION
The goal of the PR is to provide:

- a flyway-based schemas creation tool
- a data migration tool using  the legacy journal DAO to the new journal DAO

I have tested the SchemaUtils with some PoC and it works like magic. I could not move data from the old journal to the new journal though. I did not get any error when running the application.

@octonato, @ennru  and @patriknw kindly take a look and advice.