### PR TITLE
Fix performance of _highestSequenceNrForPersistenceId slick query

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalQueries.scala
@@ -52,10 +52,10 @@ class JournalQueries(
       .update(true)
 
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).max
+    selectAllJournalForPersistenceId(persistenceId).take(1).map(_.sequenceNumber).max
 
   private def _highestMarkedSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    selectAllJournalForPersistenceId(persistenceId).filter(_.deleted === true).map(_.sequenceNumber).max
+    selectAllJournalForPersistenceId(persistenceId).filter(_.deleted === true).take(1).map(_.sequenceNumber).max
 
   val highestSequenceNrForPersistenceId = Compiled(_highestSequenceNrForPersistenceId _)
 

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/legacy/JournalQueries.scala
@@ -47,10 +47,10 @@ class JournalQueries(val profile: JdbcProfile, override val journalTableCfg: Leg
       .update(true)
 
   private def _highestSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    selectAllJournalForPersistenceId(persistenceId).map(_.sequenceNumber).max
+    selectAllJournalForPersistenceId(persistenceId).take(1).map(_.sequenceNumber).max
 
   private def _highestMarkedSequenceNrForPersistenceId(persistenceId: Rep[String]): Rep[Option[Long]] =
-    selectAllJournalForPersistenceId(persistenceId).filter(_.deleted === true).map(_.sequenceNumber).max
+    selectAllJournalForPersistenceId(persistenceId).filter(_.deleted === true).take(1).map(_.sequenceNumber).max
 
   val highestSequenceNrForPersistenceId = Compiled(_highestSequenceNrForPersistenceId _)
 


### PR DESCRIPTION
There is a problem with the performance of `_highestSequenceNrForPersistenceId` query (generated by slick).
It's causing a long recovery time on my dataset (~ 69 millions of records in the journal). Adding the limit changes the generated query and drastically improves performance (in my case it was reduces from seconds to milliseconds).

Previous query:
`select max(x2.x3) from (select "persistence_id" as x4, "sequence_number" as x3 from "event_journal" where "persistence_id" = '[id]' order by "sequence_number" desc) x2;`
```
Aggregate  (cost=8524.87..8524.88 rows=1 width=8)
  ->  Index Only Scan Backward using event_journal_pkey on event_journal  (cost=0.57..8430.38 rows=7559 width=524)
        Index Cond: (persistence_id = '[id]'::text)
```

After the change:
`explain select max(x2.x3) from (select "persistence_id" as x4, "sequence_number" as x3 from "event_journal" where "persistence_id" = '[id]' order by "sequence_number" desc limit 1) x2;`
```
Aggregate  (cost=1.70..1.71 rows=1 width=8)
  ->  Limit  (cost=0.57..1.68 rows=1 width=524)
        ->  Index Only Scan Backward using event_journal_pkey on event_journal  (cost=0.57..8430.38 rows=7559 width=524)
              Index Cond: (persistence_id = '[id]'::text)
```