### PR TITLE
Prefer filtering over columns on the tag table

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala
@@ -56,7 +56,11 @@ class ReadJournalQueries(val profile: JdbcProfile, val readJournalConfig: ReadJo
     baseTableWithTagsQuery()
       .filter(_._2.tag === tag)
       .sortBy(_._1.ordering.asc)
-      .filter(row => row._1.ordering > offset && row._1.ordering <= maxOffset)
+      // The following is equivalent to
+      //    .filter(row => row._1.ordering > offset && row._1.ordering <= maxOffset)
+      // but makes the SQL query filter over the columns on the tag table
+      // which is more efficient.
+      .filter(row => row._2.eventId > offset && row._2.eventId <= maxOffset)
       .take(max)
       .map(_._1)
   }


### PR DESCRIPTION
While running some experiments and studying the query plan for `queryByTag` over a postgres database with 153k events I found some surprising results:

### Intro: the slick query for queryByTag

Slick produces the following SQL:

```sql
select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
    x2."writer",
    x2."write_timestamp",
    x2."event_payload",
    x2."event_ser_id",
    x2."event_ser_manifest"
from "event_journal" x2, "event_tag" x3
where (
        (x3."tag" = 'carts-0')
           and (
                   (x2."ordering" > 151815)
                   and (x2."ordering" <= 153815))
          )
    and (x2."ordering" = x3."event_id")
order by x2."ordering" limit 500;
```

the query above would be for tag `carts-0` reading from offset `151815` where the max `ordering` in the journal table is `153815`. The fourth input on that query is the batch size (in this case `500`). 


### Analising how it performs

When testing different values for the *offset* and checking their query plan I noticed huge differences:


1. First, I use a reasonable offset and limit:

```sql
shopping-cart=# explain analyse select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
...
        (x3."tag" = 'carts-0')
           and (
                   (x2."ordering" > 151815)
                   and (x2."ordering" <= 153815))
          )
...
                               QUERY PLAN
-------------------------------------------------------------------------------------------------
 Limit  (cost=0.84..875.91 rows=45 width=178) (actual time=0.155..52.980 rows=402 loops=1)
   ->  Nested Loop  (cost=0.84..875.91 rows=45 width=178) (actual time=0.140..49.324 rows=402 loops=1)
         ->  Index Scan using event_journal_ordering_idx on event_journal x2  (cost=0.42..19.11 rows=220 width=178) (actual time=0.081..11.503 rows=2000 loops=1)
               Index Cond: ((ordering > 151815) AND (ordering <= 153815))
         ->  Index Only Scan using event_tag_pkey on event_tag x3  (cost=0.42..3.89 rows=1 width=8) (actual time=0.008..0.008 rows=0 loops=2000)
               Index Cond: ((event_id = x2.ordering) AND (tag = 'carts-0'::text))
               Heap Fetches: 402
 Planning Time: 0.285 ms
 Execution Time: 54.818 ms
(9 rows)
```
It produces a consistent 55ms execution time.

2. Then we try a big offset and equal limit. This processor is lagging behind...

```sql
shopping-cart=# explain analyse select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
...
        (x3."tag" = 'carts-0')
           and (
                   (x2."ordering" > 141815)
                   and (x2."ordering" <= 153815))
          )
...
                               QUERY PLAN
-------------------------------------------------------------------------------------------------
 Limit  (cost=2936.03..2936.71 rows=270 width=178) (actual time=448.314..454.791 rows=500 loops=1)
   ->  Sort  (cost=2936.03..2936.71 rows=270 width=178) (actual time=448.303..450.377 rows=500 loops=1)
         Sort Key: x2.ordering
         Sort Method: top-N heapsort  Memory: 195kB
         ->  Hash Join  (cost=101.96..2925.13 rows=270 width=178) (actual time=369.357..436.492 rows=2399 loops=1)
               Hash Cond: (x3.event_id = x2.ordering)
               ->  Seq Scan on event_tag x3  (cost=0.00..2740.32 rows=31560 width=8) (actual time=0.012..156.151 rows=31132 loops=1)
                     Filter: ((tag)::text = 'carts-0'::text)
                     Rows Removed by Filter: 122683
               ->  Hash  (cost=85.44..85.44 rows=1322 width=178) (actual time=133.680..133.693 rows=12000 loops=1)
                     Buckets: 16384 (originally 2048)  Batches: 1 (originally 1)  Memory Usage: 2671kB
                     ->  Index Scan using event_journal_ordering_idx on event_journal x2  (cost=0.42..85.44 rows=1322 width=178) (actual time=0.038..70.999 rows=12000 loops=1)
                           Index Cond: ((ordering > 141815) AND (ordering <= 153815))
 Planning Time: 0.225 ms
 Execution Time: 456.892 ms
(15 rows)
```
And the execution time does increase and even the query plan looks completely different (including a sequential scan to filter by tag).

3. Here's where things get weird. This is now a query for a (almost) new projection that has the full journal to catch up on:

```sql
shopping-cart=# explain analyse select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
...
        (x3."tag" = 'carts-0')
           and (
                   (x2."ordering" > 15)
                   and (x2."ordering" <= 153815))
          )
...
                               QUERY PLAN
-------------------------------------------------------------------------------------------------
 Limit  (cost=1.15..219.65 rows=500 width=178) (actual time=0.160..17.538 rows=500 loops=1)
   ->  Merge Join  (cost=1.15..13770.12 rows=31508 width=178) (actual time=0.150..12.829 rows=500 loops=1)
         Merge Cond: (x2.ordering = x3.event_id)
         ->  Index Scan using event_journal_ordering_idx on event_journal x2  (cost=0.42..9193.54 rows=153527 width=178) (actual time=0.019..2.816 rows=500 loops=1)
               Index Cond: ((ordering > 15) AND (ordering <= 153815))
         ->  Index Only Scan using event_tag_pkey on event_tag x3  (cost=0.42..3834.17 rows=31511 width=8) (actual time=0.018..2.567 rows=511 loops=1)
               Index Cond: (tag = 'carts-0'::text)
               Heap Fetches: 0
 Planning Time: 0.209 ms
 Execution Time: 19.825 ms
(10 rows)
```
And the execution time goes back to similar values (or better) than in case `1.`. 


### Proposed solution

The columns `journal.ordering` and `event_tag.event_id` contain the same values (`event_tag.event_id` has a foreign key to `journal.ordering`). Then, we can alter the filter condition so the index in event_tag is used both by the tag equality and the offset range:

```sql
shopping-cart=# explain analyse select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
    x2."writer",
    x2."write_timestamp",
    x2."event_payload",
    x2."event_ser_id",
    x2."event_ser_manifest"
from "event_journal" x2, "event_tag" x3
where (
        (x3."tag" = 'carts-0')
           and (
                   (x3."event_id" > 151815)  <--- here's the change
                   and (x3."event_id" <= 153815))   <--- here's the change
          )
    and (x2."ordering" = x3."event_id")
order by x2."ordering" limit 500;
```

When doing that, here's what happens:

Execution Time | 1st query (151815-153815) | 2nd query (141815-153815) | 3rd query (15-153815)
------------ | ------------- | ------------ | ------------- 
original slick | ~50ms | ~450ms | ~18ms
modified | ~17.5ms | ~20.4ms | ~18.7ms

<details>
<summary>Full details</summary>


Taking the baseline queryByTag queries, prefer using the tab columns when filtering so the journal index is only used for ordering

1. :

```sql
shopping-cart=# explain analyse select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
    x2."writer",
    x2."write_timestamp",
    x2."event_payload",
    x2."event_ser_id",
    x2."event_ser_manifest"
from "event_journal" x2, "event_tag" x3
where (
        (x3."tag" = 'carts-0')
           and (
                   (x3."event_id" > 151815)
                   and (x3."event_id" <= 153815))
          )
    and (x2."ordering" = x3."event_id")
order by x2."ordering" limit 500;
                                                                         QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.84..379.30 rows=45 width=178) (actual time=0.065..15.550 rows=402 loops=1)
   ->  Nested Loop  (cost=0.84..379.30 rows=45 width=178) (actual time=0.050..11.572 rows=402 loops=1)
         ->  Index Only Scan using event_tag_pkey on event_tag x3  (cost=0.42..7.61 rows=45 width=8) (actual time=0.018..2.106 rows=402 loops=1)
               Index Cond: ((event_id > 151815) AND (event_id <= 153815) AND (tag = 'carts-0'::text))
               Heap Fetches: 0
         ->  Index Scan using event_journal_ordering_idx on event_journal x2  (cost=0.42..8.26 rows=1 width=178) (actual time=0.007..0.007 rows=1 loops=402)
               Index Cond: (ordering = x3.event_id)
 Planning Time: 0.261 ms
 Execution Time: 17.569 ms
(9 rows)
```

2. Then we try a big offset and equal limit. 

```sql
shopping-cart=# explain analyse select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
    x2."writer",
    x2."write_timestamp",
    x2."event_payload",
    x2."event_ser_id",
    x2."event_ser_manifest"
from "event_journal" x2, "event_tag" x3
where (
        (x3."tag" = 'carts-0')
           and (
                   (x3."event_id" > 141815)
                   and (x3."event_id" <= 153815))
          )
    and (x2."ordering" = x3."event_id")
order by x2."ordering" limit 500;
                                                                         QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.84..2038.09 rows=271 width=178) (actual time=0.059..18.178 rows=500 loops=1)
   ->  Nested Loop  (cost=0.84..2038.09 rows=271 width=178) (actual time=0.049..13.713 rows=500 loops=1)
         ->  Index Only Scan using event_tag_pkey on event_tag x3  (cost=0.42..43.53 rows=271 width=8) (actual time=0.021..2.439 rows=500 loops=1)
               Index Cond: ((event_id > 141815) AND (event_id <= 153815) AND (tag = 'carts-0'::text))
               Heap Fetches: 0
         ->  Index Scan using event_journal_ordering_idx on event_journal x2  (cost=0.42..7.36 rows=1 width=178) (actual time=0.007..0.007 rows=1 loops=500)
               Index Cond: (ordering = x3.event_id)
 Planning Time: 0.192 ms
 Execution Time: 20.472 ms
(9 rows)

```

3. This is now a query for a completely new projection that has the full journal to catch up on:

```sql
explain analyse select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
    x2."writer",
    x2."write_timestamp",
    x2."event_payload",
    x2."event_ser_id",
    x2."event_ser_manifest"
from "event_journal" x2, "event_tag" x3
where (
        (x3."tag" = 'carts-0')
           and (
                   (x3."event_id" > 15)
                   and (x3."event_id" <= 153815))
          )
    and (x2."ordering" = x3."event_id")
order by x2."ordering" limit 500;
                                                                             QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.13..219.43 rows=500 width=178) (actual time=0.238..16.581 rows=500 loops=1)
   ->  Merge Join  (cost=1.13..13757.42 rows=31508 width=178) (actual time=0.228..12.262 rows=500 loops=1)
         Merge Cond: (x2.ordering = x3.event_id)
         ->  Index Scan using event_journal_ordering_idx on event_journal x2  (cost=0.42..8426.16 rows=153544 width=178) (actual time=0.012..2.934 rows=515 loops=1)
         ->  Index Only Scan using event_tag_pkey on event_tag x3  (cost=0.42..4595.69 rows=31508 width=8) (actual time=0.023..2.304 rows=500 loops=1)
               Index Cond: ((event_id > 15) AND (event_id <= 153815) AND (tag = 'carts-0'::text))
               Heap Fetches: 0
 Planning Time: 0.221 ms
 Execution Time: 18.745 ms
(9 rows)
```

*CONCLUSION*: Using the tag table column (`event_id`) for filtering makes the execution time of the query much faster and stable.



### Filter and order over a single index

Taking the baseline queryByTag queries, prefer using the tab columns when filtering so the journal index is only used for ordering

1. A somewhat regular query:

```sql
shopping-cart=# explain analyse select x2."ordering",
    x2."persistence_id",
    x2."sequence_number",
    x2."writer",
    x2."write_timestamp",
    x2."event_payload",
    x2."event_ser_id",
    x2."event_ser_manifest"
from "event_journal" x2, "event_tag" x3
where (
        (x3."tag" = 'carts-0')
           and (
                   (x3."event_id" > 151815)
                   and (x3."event_id" <= 153815))
          )
    and (x2."ordering" = x3."event_id")
order by x3."event_id" limit 500;

                                                                         QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.84..379.30 rows=45 width=186) (actual time=0.063..14.669 rows=402 loops=1)
   ->  Nested Loop  (cost=0.84..379.30 rows=45 width=186) (actual time=0.051..10.953 rows=402 loops=1)
         ->  Index Only Scan using event_tag_pkey on event_tag x3  (cost=0.42..7.61 rows=45 width=8) (actual time=0.019..2.092 rows=402 loops=1)
               Index Cond: ((event_id > 151815) AND (event_id <= 153815) AND (tag = 'carts-0'::text))
               Heap Fetches: 0
         ->  Index Scan using event_journal_ordering_idx on event_journal x2  (cost=0.42..8.26 rows=1 width=178) (actual time=0.007..0.007 rows=1 loops=402)
               Index Cond: (ordering = x3.event_id)
 Planning Time: 0.215 ms
 Execution Time: 16.660 ms
(9 rows)
```


</details>

