### PR TITLE
Force mima to use 5.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,12 @@ lazy val core = project
     name := "akka-persistence-jdbc",
     libraryDependencies ++= Dependencies.Libraries,
     mimaReportSignatureProblems := true,
-    mimaPreviousArtifacts := Set(
-      organization.value %% name.value % previousStableVersion.value.getOrElse(
-        throw new Error("Unable to determine previous version for MiMa"))))
+    mimaPreviousArtifacts := Set(organization.value %% name.value % "5.0.2")
+      // FIXME: revert it after releasing 5.0.4
+      // Set(
+      // organization.value %% name.value % previousStableVersion.value.getOrElse(
+      //   throw new Error("Unable to determine previous version for MiMa")))
+    )
 
 lazy val migration = project
   .in(file("migration"))

--- a/build.sbt
+++ b/build.sbt
@@ -21,11 +21,11 @@ lazy val core = project
     libraryDependencies ++= Dependencies.Libraries,
     mimaReportSignatureProblems := true,
     mimaPreviousArtifacts := Set(organization.value %% name.value % "5.0.2")
-      // FIXME: revert it after releasing 5.0.4
-      // Set(
-      // organization.value %% name.value % previousStableVersion.value.getOrElse(
-      //   throw new Error("Unable to determine previous version for MiMa")))
-    )
+    // FIXME: revert it after releasing 5.0.4
+    // Set(
+    // organization.value %% name.value % previousStableVersion.value.getOrElse(
+    //   throw new Error("Unable to determine previous version for MiMa")))
+  )
 
 lazy val migration = project
   .in(file("migration"))


### PR DESCRIPTION
We need to force mima to use 5.0.2 because 5.0.3 never got published. 