### PR TITLE
fix: fail fast in query tests if actors fail to stop 

### DIFF
--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -171,8 +171,8 @@ abstract class EventsByPersistenceIdTest(config: String) extends QueryTestSpec(c
 
   it should "deliver EventEnvelopes non-zero timestamps" in withActorSystem { implicit system =>
     val journalOps = new ScalaJdbcReadJournalOperations(system)
+    val testStartTime = System.currentTimeMillis()
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
-      val testStartTime = System.currentTimeMillis()
 
       (actor1 ? withTags(1, "number")).futureValue
       (actor2 ? withTags(2, "number")).futureValue

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -120,11 +120,10 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "deliver EventEnvelopes non-zero timestamps" in withActorSystem { implicit system =>
-
+    val testStartTimeNs = System.currentTimeMillis()
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
 
-      val testStartTime = System.currentTimeMillis()
 
       (actor1 ? withTags(1, "number")).futureValue
       (actor2 ? withTags(2, "number")).futureValue

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -124,7 +124,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
 
-
       (actor1 ? withTags(1, "number")).futureValue
       (actor2 ? withTags(2, "number")).futureValue
       (actor3 ? withTags(3, "number")).futureValue

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -120,7 +120,7 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "deliver EventEnvelopes non-zero timestamps" in withActorSystem { implicit system =>
-    val testStartTimeNs = System.currentTimeMillis()
+    val testStartTime = System.currentTimeMillis()
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
 


### PR DESCRIPTION
References #540

I have a suspicion about the H2ScalaEventsByTagTest failures being
about journal init, but not sure. This will help pinpointing that.

