### PR TITLE
fix: The new events-by-tag-buffer-sizes-per-query could miss events

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -269,7 +269,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
               /* If no events matched the tag between `from` and `maxOrdering` then there is no need to execute the exact
                * same query again. We can continue querying from `maxOrdering`, which will save some load on the db.
                * (Note: we may never return a value smaller than `from`, otherwise we might return duplicate events) */
-              math.max(from, queryUntil.maxOrdering)
+              math.max(from, loopMaxOrderingId.maxOrdering)
             } else {
               // Continue querying from the largest offset
               xs.map(_.offset.value).max

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByUnfrequentTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByUnfrequentTagTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.query
+
+import akka.pattern.ask
+import akka.persistence.jdbc.query.EventsByUnfrequentTagTest._
+import akka.persistence.query.{ EventEnvelope, NoOffset, Sequence }
+import com.typesafe.config.{ ConfigValue, ConfigValueFactory }
+
+import scala.concurrent.duration._
+
+object EventsByUnfrequentTagTest {
+  val maxBufferSize = 20
+  val refreshInterval = 500.milliseconds
+
+  val configOverrides: Map[String, ConfigValue] = Map(
+    "jdbc-read-journal.events-by-tag-buffer-sizes-per-query" -> ConfigValueFactory.fromAnyRef(1.toString),
+    "jdbc-read-journal.max-buffer-size" -> ConfigValueFactory.fromAnyRef(maxBufferSize.toString),
+    "jdbc-read-journal.refresh-interval" -> ConfigValueFactory.fromAnyRef(refreshInterval.toString()))
+}
+
+abstract class EventsByUnfrequentTagTest(config: String) extends QueryTestSpec(config, configOverrides) {
+
+  final val NoMsgTime: FiniteDuration = 100.millis
+  it should "persist and find a tagged event with multiple (frequently and unfrequently) tags" in withActorSystem {
+    implicit system =>
+      pendingIfOracleWithLegacy()
+
+      val journalOps = new ScalaJdbcReadJournalOperations(system)
+      withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
+        val often = "often"
+        val notOften = "not-often"
+        withClue("Persisting multiple tagged events") {
+          (0 until 100).foreach { i =>
+            val additional = if (i % 40 == 0) {
+              Seq(notOften)
+            } else Seq.empty
+            val tags = Seq(often) ++ additional
+            (actor1 ? withTags(1, tags: _*)).futureValue
+          }
+
+          eventually {
+            journalOps.countJournal.futureValue shouldBe 100
+          }
+          journalOps.withEventsByTag()(often, NoOffset) { tp =>
+            tp.request(Int.MaxValue)
+            (0 until 100).foreach { i =>
+              tp.expectNextPF { case EventEnvelope(Sequence(i), _, _, _) => }
+            }
+            tp.cancel()
+            tp.expectNoMessage(NoMsgTime)
+          }
+
+          journalOps.withEventsByTag(10.seconds)(notOften, NoOffset) { tp =>
+            tp.request(Int.MaxValue)
+            tp.expectNextPF { case EventEnvelope(Sequence(1), _, _, _) => }
+            tp.expectNextPF { case EventEnvelope(Sequence(41), _, _, _) => }
+            tp.expectNextPF { case EventEnvelope(Sequence(81), _, _, _) => }
+
+            tp.cancel()
+            tp.expectNoMessage(NoMsgTime)
+          }
+        }
+
+      }
+  }
+
+}
+
+class H2ScalaEventsByUnfrequentTagTest extends EventsByUnfrequentTagTest("h2-shared-db-application.conf") with H2Cleaner


### PR DESCRIPTION
for infrequent tags because of an optimization that only works for full journal querying

Follow up to #681
