### PR TITLE
ci: renovate GH workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
-      - migration-tool # remove before merging to master
     tags-ignore: [ v.* ]
+
+permissions:
+  contents: read
 
 jobs:
   check-code-style:
@@ -14,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -25,13 +28,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Code style check and binary-compatibility check
         # Run locally with: sbt 'verifyCodeStyle ; mimaReportBinaryIssues'
@@ -42,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -52,13 +55,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Compile all code with fatal warnings for Java 11, Scala 2.12 and Scala 2.13
         # Run locally with: sbt 'clean ; +Test/compile ; +It/compile'
@@ -69,7 +72,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -79,13 +82,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Create all API docs for artifacts/website and all reference docs
         run: sbt docs/paradox

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # At 00:00 on Sunday
 
+permissions:
+  contents: read
+
 jobs:
   fossa:
     name: Fossa
@@ -12,18 +15,18 @@ jobs:
     if: github.repository == 'akka/akka-persistence-jdbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:11
+          jvm: temurin:1.11.0
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/h2-test.yml
+++ b/.github/workflows/h2-test.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
-      - migration-tool # remove before merging to master
     tags-ignore: [ v.* ]
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -16,13 +19,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,      scala-version: 2.12.x, sbt-opts: '' }
-          - { java-version: adopt@1.8,      scala-version: 2.13.x,  sbt-opts: '' }
-          - { java-version: adopt@1.11.0-9, scala-version: 2.12.x, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { java-version: adopt@1.11.0-9, scala-version: 2.13.x,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          # leaving out some combinations (note that `checks.yml` doesn't run H2 test)
+          - { scalaVersion: "2.12", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          # { scalaVersion: "2.12", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+
+          - { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+
+          # { scalaVersion: "3.1",  jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          # { scalaVersion: "3.1",  jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          # { scalaVersion: "3.1",  jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -32,16 +43,16 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup JDK ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: Run tests with Scala ${{ matrix.scalaVersion }} on JDK ${{ matrix.jdkVersion }}
+        run: sbt "+~${{ matrix.scalaVersion }} test" ${{ matrix.extraOpts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -6,13 +6,16 @@ on:
   schedule:
     - cron:  '0 6 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   validate-links:
     runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka-persistence-jdbc'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # See https://github.com/actions/checkout/issues/299#issuecomment-677674415
           ref: ${{ github.event.pull_request.head.sha }}
@@ -22,12 +25,12 @@ jobs:
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11 and Coursier
-        uses: coursier/setup-action@v1
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:11
+          jvm: temurin:1.11.0
           apps: cs
 
       - name: sbt site

--- a/.github/workflows/mysql-tests.yml
+++ b/.github/workflows/mysql-tests.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
-      - migration-tool # remove before merging to master
     tags-ignore: [ v.* ]
+
+permissions:
+  contents: read
 
 jobs:
    integration-test:
@@ -21,7 +24,7 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -31,13 +34,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK adopt@1.11.0-11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Start docker
         run: ./scripts/launch-mysql.sh

--- a/.github/workflows/oracle-tests.yml
+++ b/.github/workflows/oracle-tests.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
-      - migration-tool # remove before merging to master
     tags-ignore: [ v.* ]
+
+permissions:
+  contents: read
 
 jobs:
    integration-test:
@@ -21,7 +24,7 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -31,13 +34,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK adopt@1.11.0-11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Start docker
         run: ./scripts/launch-oracle.sh

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
-      - migration-tool # remove before merging to master
     tags-ignore: [ v.* ]
+
+permissions:
+  contents: read
 
 jobs:
    integration-test:
@@ -21,7 +24,7 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -31,13 +34,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK adopt@1.11.0-11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Start docker
         run: ./scripts/launch-postgres.sh

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,13 +7,19 @@ on:
     - main
     - release-*
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-22.04
+    if: github.repository == 'akka/akka-persistence-jdbc'
+    permissions:
+      contents: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged
-      # https://github.com/raboof/release-drafter/releases
-      # fork of https://github.com/release-drafter/release-drafter/releases
-      - uses: raboof/release-drafter@v5
+      # https://github.com/release-drafter/release-drafter/releases
+      # v5.21.1
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,12 @@ name: Release
 on:
   push:
     branches:
+      - main
       - master
-    tags: ["*"]
+    tags: ["v.*"]
+
+permissions:
+  contents: read
 
 jobs:
   release:
@@ -17,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -28,13 +32,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8.0-275
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.8.0-352
 
       - name: Publish artifacts for all Scala versions
         env:
@@ -53,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -64,14 +68,14 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
-      
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
+
       - name: Publish API and reference documentation
         env:
           GUSTAV_KEY: ${{ secrets.GUSTAV_KEY }}

--- a/.github/workflows/sqlserver-tests.yml
+++ b/.github/workflows/sqlserver-tests.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - master
-      - migration-tool # remove before merging to master
     tags-ignore: [ v.* ]
+
+permissions:
+  contents: read
 
 jobs:
    integration-test:
@@ -21,7 +24,7 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -31,13 +34,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK adopt@1.11.0-11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Start docker
         run: ./scripts/launch-sqlserver.sh


### PR DESCRIPTION
Update to current versions of GH actions before Node 12 is discontinued.
* Temurin JDKs, run some tests on JDK 17
* Replace `olafurpg/setup-scala` with `coursier/setup-action`
* Ubuntu-22.04 while at it
* Locking "privately owned" actions to their git hash 
* Explicit permissions (see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

References https://github.com/akka/akka/pull/31730