### PR TITLE
Support schema in upsert for durable store

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/state/DurableStateQueries.scala
@@ -47,7 +47,7 @@ import akka.persistence.jdbc.config.DurableStateTableConfiguration
     durableStateTable.filter(_.persistenceId === persistenceId)
 
   private[jdbc] def insertDbWithDurableState(row: DurableStateTables.DurableStateRow, seqNextValue: String) = {
-    sqlu"""INSERT INTO #${durableStateTableCfg.tableName}
+    sqlu"""INSERT INTO #${durableStateTableCfg.schemaName}.#${durableStateTableCfg.tableName}
             (
              #${durableStateTableCfg.columnNames.persistenceId},
              #${durableStateTableCfg.columnNames.globalOffset},
@@ -73,7 +73,7 @@ import akka.persistence.jdbc.config.DurableStateTableConfiguration
   }
 
   private[jdbc] def updateDbWithDurableState(row: DurableStateTables.DurableStateRow, seqNextValue: String) = {
-    sqlu"""UPDATE #${durableStateTableCfg.tableName}
+    sqlu"""UPDATE #${durableStateTableCfg.schemaName}.#${durableStateTableCfg.tableName}
            SET #${durableStateTableCfg.columnNames.globalOffset} = #${seqNextValue},
                #${durableStateTableCfg.columnNames.revision} = ${row.revision},
                #${durableStateTableCfg.columnNames.statePayload} = ${row.statePayload},

--- a/core/src/main/scala/akka/persistence/jdbc/state/SequenceNextValUpdater.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/state/SequenceNextValUpdater.scala
@@ -46,7 +46,7 @@ import slick.sql.SqlStreamingAction
     extends SequenceNextValUpdater {
   import profile.api._
   final val nextValFetcher =
-    s"""(SELECT nextval(pg_get_serial_sequence('${durableStateTableCfg.tableName}', '${durableStateTableCfg.columnNames.globalOffset}')))"""
+    s"""(SELECT nextval(pg_get_serial_sequence('${durableStateTableCfg.schemaName}.${durableStateTableCfg.tableName}', '${durableStateTableCfg.columnNames.globalOffset}')))"""
 
   def getSequenceNextValueExpr() = sql"""#$nextValFetcher""".as[String]
 }


### PR DESCRIPTION
The durable state store has configuration for a schema of the durable_state table. This configuration seems to be supported for the get and delete object methods, but not for the upsert method. This PR adds support for that configuration when upserting.

This is an addition to changes in #575 