### PR TITLE
docs: Wrong latest version in the migration guide

### DIFF
--- a/docs/src/main/paradox/migration.md
+++ b/docs/src/main/paradox/migration.md
@@ -1,8 +1,8 @@
 # Migration
 
-## Migrating to version 6.0.0
+## Migrating to version 5.2.0
 
-**Release `6.0.0` updates H2 to version 2.1.212 which is not compatible to the previous 1.4.200***
+**Release `5.2.0` updates H2 to version 2.1.214 which is not compatible to the previous 1.4.200***
 
 H2 has undergone considerable changes that broke backwards compatibility to make H2 SQL Standard compliant.
 For migration please refer to the H2 [migration guide](https://www.h2database.com/html/migration-to-v2.html)


### PR DESCRIPTION
References #720
