### PR TITLE
fix: Avoid using boolean types under Oracle's data type limitations #673

### DIFF
--- a/core/src/it/scala/akka/persistence/jdbc/integration/EventsByTagTest.scala
+++ b/core/src/it/scala/akka/persistence/jdbc/integration/EventsByTagTest.scala
@@ -6,8 +6,6 @@ class PostgresScalaEventsByTagTest extends EventsByTagTest("postgres-application
 
 class MySQLScalaEventByTagTest extends EventsByTagTest("mysql-application.conf") with MysqlCleaner
 
-class OracleScalaEventByTagTest extends EventsByTagTest("oracle-application.conf") with OracleCleaner {
-  override def timeoutMultiplier: Int = 4
-}
+class OracleScalaEventByTagTest extends EventsByTagTest("oracle-application.conf") with OracleCleaner
 
 class SqlServerScalaEventByTagTest extends EventsByTagTest("sqlserver-application.conf") with SqlServerCleaner

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/legacy/ByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/legacy/ByteArrayReadJournalDao.scala
@@ -122,7 +122,7 @@ trait OracleReadJournalDao extends ReadJournalDao {
     if (isOracleDriver(profile)) {
       val theOffset = Math.max(0, offset)
       val theTag = s"%$tag%"
-
+      // fixes https://github.com/akka/akka-persistence-jdbc/issues/673, oracle do not support boolean type.
       val selectStatement =
         sql"""
             SELECT "#$ordering", "#$deleted", "#$persistenceId", "#$sequenceNumber", "#$message", "#$tags"
@@ -131,7 +131,7 @@ trait OracleReadJournalDao extends ReadJournalDao {
               WHERE "#$tags" LIKE $theTag
               AND "#$ordering" > $theOffset
               AND "#$ordering" <= $maxOffset
-              AND "#$deleted" = 'false'
+              AND "#$deleted" = 0
               ORDER BY "#$ordering"
             )
             WHERE rownum <= $max""".as[JournalRow]

--- a/core/src/main/scala/akka/persistence/jdbc/query/dao/legacy/ByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/query/dao/legacy/ByteArrayReadJournalDao.scala
@@ -122,7 +122,6 @@ trait OracleReadJournalDao extends ReadJournalDao {
     if (isOracleDriver(profile)) {
       val theOffset = Math.max(0, offset)
       val theTag = s"%$tag%"
-      // fixes https://github.com/akka/akka-persistence-jdbc/issues/673, oracle do not support boolean type.
       val selectStatement =
         sql"""
             SELECT "#$ordering", "#$deleted", "#$persistenceId", "#$sequenceNumber", "#$message", "#$tags"

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -45,7 +45,6 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
   }
 
   it should "find all events by tag" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
@@ -94,7 +93,6 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
   }
 
   it should "persist and find a tagged event with multiple tags" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
@@ -169,7 +167,6 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
 
   it should "complete without any gaps in case events are being persisted when the query is executed" in withActorSystem {
     implicit system =>
-      pendingIfOracleWithLegacy()
 
       val journalOps = new JavaDslJdbcReadJournalOperations(system)
       import system.dispatcher

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -74,7 +74,6 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
   }
 
   it should "apply event adapters when querying events by tag from an offset" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
@@ -139,7 +138,6 @@ abstract class EventAdapterTest(config: String) extends QueryTestSpec(config) {
   }
 
   it should "apply event adapters when querying all current events by tag" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -48,7 +48,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "find all events by tag" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
@@ -122,7 +121,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "deliver EventEnvelopes non-zero timestamps" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val testStartTime = System.currentTimeMillis()
     val journalOps = new ScalaJdbcReadJournalOperations(system)
@@ -159,7 +157,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "select events by tag with exact match" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new ScalaJdbcReadJournalOperations(system)
 
@@ -201,7 +198,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
 
   it should "find all events by tag even when lots of events are persisted concurrently" in withActorSystem {
     implicit system =>
-      pendingIfOracleWithLegacy()
 
       val journalOps = new ScalaJdbcReadJournalOperations(system)
       val msgCountPerActor = 20
@@ -232,7 +228,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "find events by tag from an offset" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new JavaDslJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
@@ -259,7 +254,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "persist and find tagged event for one tag" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new JavaDslJdbcReadJournalOperations(system)
     withTestActors() { (actor1, actor2, actor3) =>
@@ -306,7 +300,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   }
 
   it should "persist and find tagged events when stored with multiple tags" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     val journalOps = new ScalaJdbcReadJournalOperations(system)
     withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
@@ -385,7 +378,6 @@ abstract class EventsByTagTest(config: String) extends QueryTestSpec(config, con
   def timeoutMultiplier: Int = 1
 
   it should "show the configured performance characteristics" in withActorSystem { implicit system =>
-    pendingIfOracleWithLegacy()
 
     import system.dispatcher
     val journalOps = new ScalaJdbcReadJournalOperations(system)

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventsByUnfrequentTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventsByUnfrequentTagTest.scala
@@ -27,7 +27,6 @@ abstract class EventsByUnfrequentTagTest(config: String) extends QueryTestSpec(c
   final val NoMsgTime: FiniteDuration = 100.millis
   it should "persist and find a tagged event with multiple (frequently and unfrequently) tags" in withActorSystem {
     implicit system =>
-      pendingIfOracleWithLegacy()
 
       val journalOps = new ScalaJdbcReadJournalOperations(system)
       withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>

--- a/core/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/QueryTestSpec.scala
@@ -286,14 +286,6 @@ abstract class QueryTestSpec(config: String, configOverrides: Map[String, Config
       }
   }
 
-  def pendingIfOracleWithLegacy(): Unit = {
-    if (
-      profile == slick.jdbc.OracleProfile && readJournalConfig.pluginConfig.dao == classOf[
-        akka.persistence.jdbc.query.dao.legacy.ByteArrayReadJournalDao].getName
-    )
-      pending // TODO https://github.com/akka/akka-persistence-jdbc/issues/673
-  }
-
   def setupEmpty(persistenceId: Int, replyToMessages: Boolean)(implicit system: ActorSystem): ActorRef = {
     system.actorOf(Props(new TestActor(persistenceId, replyToMessages)))
   }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #673

This PR has been fix something like `EventsByTagTest`, but i got the ERROR on `JournalSequenceActorTest`.

I think it was my environment complaining database too slow, waiting for investigation.