### PR TITLE
perf: Reducing memory cost while replaying

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -118,7 +118,7 @@ class JdbcAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
     journalDao
       .messagesWithBatch(persistenceId, fromSequenceNr, toSequenceNr, journalConfig.daoConfig.replayBatchSize, None)
       .take(max)
-      .mapAsync(1)(reprAndOrdNr => Future.fromTry(reprAndOrdNr))
+      .collect { case Success(reprAndOrdNr) => reprAndOrdNr }
       .runForeach { case (repr, _) =>
         recoveryCallback(repr)
       }

--- a/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -118,9 +118,10 @@ class JdbcAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
     journalDao
       .messagesWithBatch(persistenceId, fromSequenceNr, toSequenceNr, journalConfig.daoConfig.replayBatchSize, None)
       .take(max)
-      .collect { case Success(reprAndOrdNr) => reprAndOrdNr }
-      .runForeach { case (repr, _) =>
-        recoveryCallback(repr)
+      .runForeach {
+        case Success((repr, _)) =>
+          recoveryCallback(repr)
+        case Failure(ex) => throw ex
       }
       .map(_ => ())
 

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/BaseJournalDaoWithReadMessages.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/BaseJournalDaoWithReadMessages.scala
@@ -12,7 +12,6 @@ import akka.persistence.jdbc.journal.dao.FlowControl.{ Continue, ContinueDelayed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{ Sink, Source }
 
-import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{ Failure, Success, Try }
@@ -67,7 +66,7 @@ trait BaseJournalDaoWithReadMessages extends JournalDaoWithReadMessages {
               akka.pattern.after(delay, scheduler)(retrieveNextBatch())
           }
       }
-      .mapConcat(identity(_))
+      .mapConcat(identity)
   }
 
 }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
No References.

#### Motivation:

Reducing memory cost on replaying query stream

#### Result

Additional bonus: slight performance improvement.

```bash
jmh:run -i 3 -wi 3 -f 1 .JdbcAsyncJournalBenchmark

[info] Benchmark                                     Mode  Cnt       Score       Error  Units
[info] JdbcAsyncJournalBenchmark.originalAsync      thrpt    3  590394.058 ± 38433.920  ops/s
[info] JdbcAsyncJournalBenchmark.streamWithCollect  thrpt    3  594978.499 ±  2034.776  ops/s

[info] Benchmark                                     Mode  Cnt       Score       Error  Units
[info] JdbcAsyncJournalBenchmark.originalAsync      thrpt    3  584438.653 ± 35769.421  ops/s
[info] JdbcAsyncJournalBenchmark.streamWithCollect  thrpt    3  587042.327 ± 15553.554  ops/s
```

JMH for this change: https://gist.github.com/Roiocam/aabbf404aa2e1a4e967967e450b0def0