### PR TITLE
bump: Akka Paradox; remove old references in readmes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,5 @@ Example:
 
 ## How To Enforce These Guidelines?
 
-1. [Travis CI](https://travis-ci.org/akka/akka-persistence-jdbc) automatically merges the code, builds it, runs the tests and sets Pull Request status accordingly of results in GitHub.
 2. [Scalafmt](https://scalameta.org/scalafmt/) enforces some of the code style rules.
 3. [sbt-header plugin](https://github.com/sbt/sbt-header) manages consistent copyright headers in every source file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,5 +78,5 @@ Example:
 
 ## How To Enforce These Guidelines?
 
-2. [Scalafmt](https://scalameta.org/scalafmt/) enforces some of the code style rules.
-3. [sbt-header plugin](https://github.com/sbt/sbt-header) manages consistent copyright headers in every source file.
+1. [Scalafmt](https://scalameta.org/scalafmt/) enforces some of the code style rules.
+2. [sbt-header plugin](https://github.com/sbt/sbt-header) manages consistent copyright headers in every source file.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Akka Persistence JDBC
 ## Use JDBC-compatible databases with Akka Persistence
 
-[![Build Status](https://travis-ci.com/akka/akka-persistence-jdbc.svg?branch=master)](https://travis-ci.com/github/akka/akka-persistence-jdbc)
-
 akka-persistence-jdbc writes journal and snapshot entries to a configured JDBC store. It implements the full akka-persistence-query API and is therefore very useful for implementing DDD-style 
 application models using Akka for creating reactive applications.
 
@@ -25,7 +23,6 @@ For the change log prior to v3.2.0, visit [Version History Page (wiki)](https://
 You can join these groups and chats to discuss and ask Akka related questions:
 
 - Forums: [discuss.akka.io](https://discuss.lightbend.com/c/akka/)
-- Chat room about **Akka**: [![gitter: akka/akka](https://img.shields.io/badge/gitter%3A-akka%2Fakka-blue.svg?style=flat-square)](https://gitter.im/akka/akka)
 - Issue tracker: [![github: akka/akka-persistence-jdbc](https://img.shields.io/badge/github%3A-issues-blue.svg?style=flat-square)](https://github.com/akka/akka-persistence-jdbc/issues)
 
 In addition to that, you may enjoy following:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.8.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 // docs
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.51")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.53")
 addSbtPlugin("com.github.sbt" % "sbt-site" % "1.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")


### PR DESCRIPTION
Even removed references to Travis and Gitter.

References
- https://github.com/akka/akka-paradox/releases/tag/v0.53