### PR TITLE
fix: flaky CurrentEventsByTagTest

### DIFF
--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -173,14 +173,13 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
       val latch = new CountDownLatch(1)
       val largeNumberOfMessage = 2000
       val smallNumberOfMessage = 200
-      val diff = largeNumberOfMessage - (smallNumberOfMessage * 3)
       val journalOps = new JavaDslJdbcReadJournalOperations(system)
       import system.dispatcher
       withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
         def sendMessagesWithTag(tag: String, numberOfMessagesPerActor: Int): Future[Done] = {
           val futures = for (actor <- Seq(actor1, actor2, actor3); i <- 1 to numberOfMessagesPerActor) yield {
             // block the remaining small batch events from being fired
-            if (i == diff) {
+            if (i > largeNumberOfMessage / 2) {
               Future {
                 latch.await()
                 actor ? TaggedAsyncEvent(Event(i.toString), tag)

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -179,9 +179,13 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
       withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
         def sendMessagesWithTag(tag: String, numberOfMessagesPerActor: Int): Future[Done] = {
           val futures = for (actor <- Seq(actor1, actor2, actor3); i <- 1 to numberOfMessagesPerActor) yield {
-            Future {
-              // block the remaining small batch events from being fired
-              if (i == diff) latch.await()
+            // block the remaining small batch events from being fired
+            if (i == diff) {
+              Future {
+                latch.await()
+                actor ? TaggedAsyncEvent(Event(i.toString), tag)
+              }
+            } else {
               actor ? TaggedAsyncEvent(Event(i.toString), tag)
             }
           }

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -16,8 +16,6 @@ import akka.persistence.jdbc.query.EventAdapterTest.{ Event, TaggedAsyncEvent }
 import scala.concurrent.Future
 import CurrentEventsByTagTest._
 
-import java.util.concurrent.CountDownLatch
-
 object CurrentEventsByTagTest {
   val maxBufferSize = 20
   val refreshInterval = 500.milliseconds
@@ -190,7 +188,7 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
         journalOps.countJournal.futureValue should be >= 600L
 
         // Try to persist a large batch of events per actor. Some of these may be returned, but not all!
-        val batch2 = sendMessagesWithTag(tag, 200)
+        val batch2 = sendMessagesWithTag(tag, 5000)
         // start the query before the last batch completes
         journalOps.withCurrentEventsByTag()(tag, NoOffset) { tp =>
           // The stream must complete within the given amount of time

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -173,7 +173,7 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
       val latch = new CountDownLatch(1)
       val largeNumberOfMessage = 2000
       val smallNumberOfMessage = 200
-      val diff = largeNumberOfMessage - smallNumberOfMessage
+      val diff = largeNumberOfMessage - (smallNumberOfMessage * 3)
       val journalOps = new JavaDslJdbcReadJournalOperations(system)
       import system.dispatcher
       withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -182,7 +182,7 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
             if (i > largeNumberOfMessage / 2) {
               Future {
                 latch.await()
-                actor ? TaggedAsyncEvent(Event(i.toString), tag)
+                (actor ? TaggedAsyncEvent(Event(i.toString), tag)) (20.seconds)
               }
             } else {
               actor ? TaggedAsyncEvent(Event(i.toString), tag)

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -16,6 +16,8 @@ import akka.persistence.jdbc.query.EventAdapterTest.{ Event, TaggedAsyncEvent }
 import scala.concurrent.Future
 import CurrentEventsByTagTest._
 
+import java.util.concurrent.CountDownLatch
+
 object CurrentEventsByTagTest {
   val maxBufferSize = 20
   val refreshInterval = 500.milliseconds
@@ -168,11 +170,16 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
   it should "complete without any gaps in case events are being persisted when the query is executed" in withActorSystem {
     implicit system =>
 
+      val latch = new CountDownLatch(1)
       val journalOps = new JavaDslJdbcReadJournalOperations(system)
       import system.dispatcher
       withTestActors(replyToMessages = true) { (actor1, actor2, actor3) =>
         def sendMessagesWithTag(tag: String, numberOfMessagesPerActor: Int): Future[Done] = {
           val futures = for (actor <- Seq(actor1, actor2, actor3); i <- 1 to numberOfMessagesPerActor) yield {
+            // block the execution
+            if (i == numberOfMessagesPerActor / 2) {
+              latch.await()
+            }
             actor ? TaggedAsyncEvent(Event(i.toString), tag)
           }
           Future.sequence(futures).map(_ => Done)
@@ -182,7 +189,7 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
         // send a batch of 3 * 200
         val batch1 = sendMessagesWithTag(tag, 200)
         // Try to persist a large batch of events per actor. Some of these may be returned, but not all!
-        val batch2 = sendMessagesWithTag(tag, 3000)
+        val batch2 = sendMessagesWithTag(tag, 2000)
 
         // wait for acknowledgement of the first batch only
         batch1.futureValue
@@ -191,6 +198,8 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
 
         // start the query before the last batch completes
         journalOps.withCurrentEventsByTag()(tag, NoOffset) { tp =>
+          // when query begin running, unlock the barrier.
+          latch.countDown()
           // The stream must complete within the given amount of time
           // This make take a while in case the journal sequence actor detects gaps
           val allEvents = tp.toStrict(atMost = 40.seconds)

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -182,7 +182,7 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
         // send a batch of 3 * 200
         val batch1 = sendMessagesWithTag(tag, 200)
         // Try to persist a large batch of events per actor. Some of these may be returned, but not all!
-        val batch2 = sendMessagesWithTag(tag, 5000)
+        val batch2 = sendMessagesWithTag(tag, 3000)
 
         // wait for acknowledgement of the first batch only
         batch1.futureValue

--- a/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -178,9 +178,13 @@ abstract class CurrentEventsByTagTest(config: String) extends QueryTestSpec(conf
           val futures = for (actor <- Seq(actor1, actor2, actor3); i <- 1 to numberOfMessagesPerActor) yield {
             // block the execution
             if (i == numberOfMessagesPerActor / 2) {
-              latch.await()
+              Future {
+                latch.await()
+                actor ? TaggedAsyncEvent(Event(i.toString), tag)
+              }
+            } else {
+              actor ? TaggedAsyncEvent(Event(i.toString), tag)
             }
-            actor ? TaggedAsyncEvent(Event(i.toString), tag)
           }
           Future.sequence(futures).map(_ => Done)
         }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #782

Delay persistence to the start of the query