### PR TITLE
build: Bump plugins to only download from maven central

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,10 +9,10 @@ addDependencyTreePlugin
 
 // release
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 // docs
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.53")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.54")
 addSbtPlugin("com.github.sbt" % "sbt-site" % "1.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
-addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
+addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.3")


### PR DESCRIPTION
As the other repos are unstable/going away: https://contributors.scala-lang.org/t/roadmap-for-the-sbt-community-repository/6195