### PR TITLE
bump: Slick 3.5.1 (was 3.5.0)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val AkkaVersion = "2.9.0"
   val AkkaBinaryVersion = AkkaVersion.take(3)
 
-  val SlickVersion = "3.5.0"
+  val SlickVersion = "3.5.1"
   val ScalaTestVersion = "3.2.18"
 
   val JdbcDrivers = Seq(


### PR DESCRIPTION
Fix for MySQL.

Slf4j-API bump is excluded since before.

References
- https://github.com/slick/slick/releases/tag/v3.5.1