### PR TITLE
fix: Workaround slick dependency issue #824

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ lazy val core = project
   .settings(
     name := "akka-persistence-jdbc",
     libraryDependencies ++= Dependencies.Libraries,
+    // Workaround for https://github.com/slick/slick/issues/2933
+    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     mimaReportSignatureProblems := true,
     mimaPreviousArtifacts := {
       if (scalaVersion.value.startsWith("3")) {

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,9 @@ lazy val core = project
     name := "akka-persistence-jdbc",
     libraryDependencies ++= Dependencies.Libraries,
     // Workaround for https://github.com/slick/slick/issues/2933
-    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+    libraryDependencies ++=
+      (if (scalaVersion.value.startsWith("2.13")) Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
+      else Nil),
     mimaReportSignatureProblems := true,
     mimaPreviousArtifacts := {
       if (scalaVersion.value.startsWith("3")) {

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val core = project
     // Workaround for https://github.com/slick/slick/issues/2933
     libraryDependencies ++=
       (if (scalaVersion.value.startsWith("2.13")) Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
-      else Nil),
+       else Nil),
     mimaReportSignatureProblems := true,
     mimaPreviousArtifacts := {
       if (scalaVersion.value.startsWith("3")) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,8 +24,6 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
     // Slick 3.5 pulls in slf4j-api 2.2 which doesn't work with Akka
     ("com.typesafe.slick" %% "slick" % SlickVersion).exclude("org.slf4j", "slf4j-api"),
-    // Workaround for https://github.com/slick/slick/issues/2933
-    "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     "org.slf4j" % "slf4j-api" % "1.7.36",
     "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
     "ch.qos.logback" % "logback-classic" % "1.2.13" % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,5 @@
 import sbt._
+import sbt.Keys.scalaVersion
 
 object Dependencies {
 
@@ -23,6 +24,8 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
     // Slick 3.5 pulls in slf4j-api 2.2 which doesn't work with Akka
     ("com.typesafe.slick" %% "slick" % SlickVersion).exclude("org.slf4j", "slf4j-api"),
+    // Workaround for https://github.com/slick/slick/issues/2933
+    "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     "org.slf4j" % "slf4j-api" % "1.7.36",
     "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
     "ch.qos.logback" % "logback-classic" % "1.2.13" % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,4 @@
 import sbt._
-import sbt.Keys.scalaVersion
 
 object Dependencies {
 


### PR DESCRIPTION
Direct dependency on scala-reflect sorts it until upstream is fixed

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #824
