### PR TITLE
fix: deserialization failure in durable state should result in failed future

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/state/scaladsl/JdbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/state/scaladsl/JdbcDurableStateStore.scala
@@ -63,10 +63,9 @@ class JdbcDurableStateStore[A](
       rows.headOption match {
         case None => Future.successful(GetObjectResult(None, 0))
         case Some(row) =>
-          Future.fromTry(
-            AkkaSerialization.fromDurableStateRow(serialization)(row).map { anyRef =>
-              GetObjectResult(Some(anyRef.asInstanceOf[A]), row.revision)
-            })
+          Future.fromTry(AkkaSerialization.fromDurableStateRow(serialization)(row).map { anyRef =>
+            GetObjectResult(Some(anyRef.asInstanceOf[A]), row.revision)
+          })
       }
     }
   }


### PR DESCRIPTION
The present implementation of the durable state store treats a deserialization failure as "successful but absent" (a `Future` containing `None`)

In contrast:
* this plugin's journal and snapshot stores will fail the future (see [journal](https://github.com/akka/akka-persistence-jdbc/blob/55f38148ff5782a0d993b8f51b810f163160587e/core/src/main/scala/akka/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala#L124) and [snapshot](https://github.com/akka/akka-persistence-jdbc/blob/55f38148ff5782a0d993b8f51b810f163160587e/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/DefaultSnapshotDao.scala#L72)
* [the R2DBC plugin's durable state store will fail the future](https://github.com/akka/akka-persistence-r2dbc/blob/93246b520a9efbdfd5d6b5205f80ab99fd9108f6/core/src/main/scala/akka/persistence/r2dbc/state/scaladsl/R2dbcDurableStateStore.scala#L123)

With this change, the behavior now matches the others: a failed try from the serializer will be a failed future.