### PR TITLE
bump: Slick 3.5.2 (was 3.5.1)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val AkkaVersion = "2.10.0-M1"
   val AkkaBinaryVersion = VersionNumber(AkkaVersion).numbers match { case Seq(major, minor, _*) => s"$major.$minor" }
 
-  val SlickVersion = "3.5.1"
+  val SlickVersion = "3.5.2"
   val ScalaTestVersion = "3.2.19"
 
   val JdbcDrivers = Seq(


### PR DESCRIPTION
References
- https://github.com/slick/slick/releases/tag/v3.5.2