### PR TITLE
fix: link validation for missing slick docsite

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -14,6 +14,12 @@ site-link-validator {
       prefix = "https://doc.akka.io/api/akka-persistence-jdbc/snapshot/"
       replace = "/api/akka-persistence-jdbc/snapshot/"
     }
+    {
+      # slick 3.5.2 doc site is removed, next version is 3.6.0
+      # we keep this exclusion as long as we stay with 3.5.2
+      prefix = "https://scala-slick.org/doc/3.5.2/"
+      replace = "https://scala-slick.org/doc/stable/"
+    }
   ]
 
   ignore-missing-local-files-regex = ""


### PR DESCRIPTION
Kinds of workaround for link validation. 

Slick doc-site for 3.5.2 is missing and we are not ready to bump to 3.6.0 (see https://github.com/akka/akka-persistence-jdbc/pull/902#issuecomment-2788446422)

So for now, I think the best we can do it to point to https://scala-slick.org/doc/stable/, although it might give the impression that we are on the latest version.