### PR TITLE
fix: revert to Slick v3.5.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val AkkaVersion = "2.10.0"
   val AkkaBinaryVersion = VersionNumber(AkkaVersion).numbers match { case Seq(major, minor, _*) => s"$major.$minor" }
 
-  val SlickVersion = "3.5.2"
+  val SlickVersion = "3.5.1"
   val ScalaTestVersion = "3.2.19"
 
   val JdbcDrivers = Seq(


### PR DESCRIPTION
as discussed in https://github.com/akka/akka-persistence-jdbc/pull/908