### PR TITLE
Added cleanup tool

### DIFF
--- a/core/src/main/mima-filters/5.5.2.backwards.excludes/pr-928-cleanup-tool.excludes
+++ b/core/src/main/mima-filters/5.5.2.backwards.excludes/pr-928-cleanup-tool.excludes
@@ -1,0 +1,3 @@
+# internal api changes
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.persistence.jdbc.journal.dao.JournalDao.deleteEventsTo")
+ProblemFilters.exclude[NewMixinForwarderProblem]("akka.persistence.jdbc.journal.dao.legacy.BaseByteArrayJournalDao.delete")

--- a/core/src/main/scala/akka/persistence/jdbc/cleanup/javadsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/cleanup/javadsl/EventSourcedCleanup.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.cleanup.javadsl
+
+import java.util.concurrent.CompletionStage
+import scala.jdk.FutureConverters._
+
+import akka.Done
+import akka.actor.ClassicActorSystemProvider
+import akka.annotation.ApiMayChange
+import akka.persistence.jdbc.cleanup.scaladsl
+
+/**
+ * Java API: Tool for deleting events and/or snapshots for a `persistenceId` without using persistent actors.
+ *
+ * When running an operation with `EventSourcedCleanup` that deletes all events for a persistence id, the actor with
+ * that persistence id must not be running! If the actor is restarted it would in that case be recovered to the wrong
+ * state since the stored events have been deleted. Delete events before snapshot can still be used while the actor is
+ * running.
+ *
+ * If `resetSequenceNumber` is `true` then the creating entity with the same `persistenceId` will start from 0.
+ * Otherwise it will continue from the latest highest used sequence number.
+ *
+ * WARNING: reusing the same `persistenceId` after resetting the sequence number should be avoided, since it might be
+ * confusing to reuse the same sequence number for new events.
+ */
+@ApiMayChange
+final class EventSourcedCleanup private (delegate: scaladsl.EventSourcedCleanup) {
+
+  def this(systemProvider: ClassicActorSystemProvider, journalConfigPath: String, snapshotConfigPath: String) =
+    this(new scaladsl.EventSourcedCleanup(systemProvider, journalConfigPath, snapshotConfigPath))
+
+  def this(systemProvider: ClassicActorSystemProvider) =
+    this(systemProvider, "jdbc-journal", "jdbc-snapshot-store")
+
+  /**
+   * Delete all events related to one single `persistenceId`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceId: String, resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAllEvents(persistenceId, resetSequenceNumber).asJava
+
+  /**
+   * Delete snapshots related to one single `persistenceId`. Events are not deleted.
+   */
+  def deleteSnapshot(persistenceId: String): CompletionStage[Done] =
+    delegate.deleteSnapshot(persistenceId).asJava
+
+  /**
+   * Delete everything related to one single `persistenceId`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceId: String, resetSequenceNumber: Boolean): CompletionStage[Done] =
+    delegate.deleteAll(persistenceId, resetSequenceNumber).asJava
+
+}

--- a/core/src/main/scala/akka/persistence/jdbc/cleanup/scaladsl/EventSourcedCleanup.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/cleanup/scaladsl/EventSourcedCleanup.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.cleanup.scaladsl
+
+import scala.concurrent.{ ExecutionContext, Future }
+import akka.Done
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
+import akka.annotation.ApiMayChange
+import akka.persistence.jdbc.config.{ JournalConfig, SnapshotConfig }
+import akka.persistence.jdbc.db.SlickExtension
+import akka.persistence.jdbc.journal.dao.JournalDaoInstantiation
+import akka.persistence.jdbc.snapshot.dao.SnapshotDaoInstantiation
+import akka.stream.{ Materializer, SystemMaterializer }
+
+/**
+ * Scala API: Tool for deleting events and/or snapshots for a `persistenceId` without using persistent actors.
+ *
+ * When running an operation with `EventSourcedCleanup` that deletes all events for a persistence id, the actor with
+ * that persistence id must not be running! If the actor is restarted it would in that case be recovered to the wrong
+ * state since the stored events have been deleted. Delete events before snapshot can still be used while the actor is
+ * running.
+ *
+ * If `resetSequenceNumber` is `true` then the creating entity with the same `persistenceId` will start from 0.
+ * Otherwise it will continue from the latest highest used sequence number.
+ *
+ * WARNING: reusing the same `persistenceId` after resetting the sequence number should be avoided, since it might be
+ * confusing to reuse the same sequence number for new events.
+ */
+@ApiMayChange
+final class EventSourcedCleanup(
+    systemProvider: ClassicActorSystemProvider,
+    journalConfigPath: String,
+    snapshotConfigPath: String) {
+
+  def this(systemProvider: ClassicActorSystemProvider) =
+    this(systemProvider, "jdbc-journal", "jdbc-snapshot-store")
+
+  private implicit val system: ActorSystem = systemProvider.classicSystem
+  private implicit val executionContext: ExecutionContext = system.dispatchers.defaultGlobalDispatcher
+  private implicit val mat: Materializer = SystemMaterializer(system).materializer
+  private val slick = SlickExtension(system)
+
+  private val journalConfig = system.settings.config.getConfig(journalConfigPath)
+  private val journalDao =
+    JournalDaoInstantiation.journalDao(new JournalConfig(journalConfig), slick.database(journalConfig))
+
+  private val snapshotConfig = system.settings.config.getConfig(snapshotConfigPath)
+  private val snapshotDao =
+    SnapshotDaoInstantiation.snapshotDao(new SnapshotConfig(snapshotConfig), slick.database(snapshotConfig))
+
+  /**
+   * Delete all events related to one single `persistenceId`. Snapshots are not deleted.
+   */
+  def deleteAllEvents(persistenceId: String, resetSequenceNumber: Boolean): Future[Done] = {
+    journalDao.deleteEventsTo(persistenceId, toSequenceNr = Long.MaxValue, resetSequenceNumber).map(_ => Done)
+  }
+
+  /**
+   * Delete snapshots related to one single `persistenceId`. Events are not deleted.
+   */
+  def deleteSnapshot(persistenceId: String): Future[Done] = {
+    snapshotDao.deleteUpToMaxSequenceNr(persistenceId, Long.MaxValue).map(_ => Done)
+  }
+
+  /**
+   * Delete everything related to one single `persistenceId`. All events and snapshots are deleted.
+   */
+  def deleteAll(persistenceId: String, resetSequenceNumber: Boolean): Future[Done] = {
+    for {
+      _ <- deleteAllEvents(persistenceId, resetSequenceNumber)
+      _ <- deleteSnapshot(persistenceId)
+    } yield Done
+  }
+}

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDao.scala
@@ -6,6 +6,8 @@
 package akka.persistence.jdbc.journal.dao
 
 import akka.persistence.AtomicWrite
+
+import java.time.Instant
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.util.Try
@@ -15,7 +17,13 @@ trait JournalDao extends JournalDaoWithReadMessages {
   /**
    * Deletes all persistent messages up to toSequenceNr (inclusive) for the persistenceId
    */
-  def delete(persistenceId: String, toSequenceNr: Long): Future[Unit]
+  def delete(persistenceId: String, toSequenceNr: Long): Future[Unit] =
+    deleteEventsTo(persistenceId, toSequenceNr, false)
+
+  /**
+   * Deletes all persistent events up to toSequenceNr (inclusive) for the persistenceId
+   */
+  def deleteEventsTo(persistenceId: String, toSequenceNr: Long, resetSequenceNumber: Boolean): Future[Unit]
 
   /**
    * Returns the highest sequence number for the events that are stored for that `persistenceId`. When no events are

--- a/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDaoInstantiation.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/journal/dao/JournalDaoInstantiation.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.journal.dao
+
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.annotation.InternalApi
+import akka.persistence.jdbc.config.JournalConfig
+import akka.persistence.jdbc.db.SlickDatabase
+import akka.serialization.{ Serialization, SerializationExtension }
+import akka.stream.Materializer
+import slick.jdbc.JdbcBackend.Database
+import slick.jdbc.JdbcProfile
+
+import scala.concurrent.ExecutionContext
+import scala.util.{ Failure, Success }
+
+@InternalApi
+private[jdbc] object JournalDaoInstantiation {
+
+  def journalDao(
+      journalConfig: JournalConfig,
+      slickDb: SlickDatabase)(implicit system: ActorSystem, ec: ExecutionContext, mat: Materializer): JournalDao = {
+    val fqcn = journalConfig.pluginConfig.dao
+    val profile: JdbcProfile = slickDb.profile
+    val args = Seq(
+      (classOf[Database], slickDb.database),
+      (classOf[JdbcProfile], profile),
+      (classOf[JournalConfig], journalConfig),
+      (classOf[Serialization], SerializationExtension(system)),
+      (classOf[ExecutionContext], ec),
+      (classOf[Materializer], mat))
+    system.asInstanceOf[ExtendedActorSystem].dynamicAccess.createInstanceFor[JournalDao](fqcn, args) match {
+      case Success(dao)   => dao
+      case Failure(cause) => throw cause
+    }
+  }
+
+}

--- a/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotDaoInstantiation.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotDaoInstantiation.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.snapshot.dao
+
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.annotation.InternalApi
+import akka.persistence.jdbc.config.SnapshotConfig
+import akka.persistence.jdbc.db.SlickDatabase
+import akka.serialization.{ Serialization, SerializationExtension }
+import akka.stream.Materializer
+import slick.jdbc.JdbcBackend.Database
+import slick.jdbc.JdbcProfile
+
+import scala.concurrent.ExecutionContext
+import scala.util.{ Failure, Success }
+
+@InternalApi
+private[jdbc] object SnapshotDaoInstantiation {
+
+  def snapshotDao(
+      snapshotConfig: SnapshotConfig,
+      slickDb: SlickDatabase)(implicit system: ActorSystem, ec: ExecutionContext, mat: Materializer): SnapshotDao = {
+    val fqcn = snapshotConfig.pluginConfig.dao
+    val profile: JdbcProfile = slickDb.profile
+    val args = Seq(
+      (classOf[Database], slickDb.database),
+      (classOf[JdbcProfile], profile),
+      (classOf[SnapshotConfig], snapshotConfig),
+      (classOf[Serialization], SerializationExtension(system)),
+      (classOf[ExecutionContext], ec),
+      (classOf[Materializer], mat))
+    system.asInstanceOf[ExtendedActorSystem].dynamicAccess.createInstanceFor[SnapshotDao](fqcn, args) match {
+      case Success(dao)   => dao
+      case Failure(cause) => throw cause
+    }
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/jdbc/cleanup/scaladsl/EventSourcedCleanupTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/cleanup/scaladsl/EventSourcedCleanupTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.cleanup.scaladsl
+
+import akka.persistence.jdbc.query.{ H2Cleaner, QueryTestSpec }
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import akka.pattern.ask
+import akka.persistence.jdbc.query.EventAdapterTest.Snapshot
+
+abstract class EventSourcedCleanupTest(config: String) extends QueryTestSpec(config) with Matchers {
+  implicit val askTimeout: FiniteDuration = 500.millis
+
+  it should "delete all events and reset sequence number" in withActorSystem { implicit system =>
+    withTestActors(replyToMessages = true) { (actor1, _, _) =>
+      (actor1 ? 1).futureValue
+      (actor1 ? 2).futureValue
+      (actor1 ? 3).futureValue
+    }
+    new EventSourcedCleanup(system).deleteAllEvents("my-1", true).futureValue
+    withTestActors(replyToMessages = true) { (actor1, _, _) =>
+      (actor1 ? "state").futureValue.asInstanceOf[Int] shouldBe 0
+    }
+  }
+
+  it should "delete snapshots as well as events" in withActorSystem { implicit system =>
+    withTestActors(replyToMessages = true) { (actor1, _, _) =>
+      (actor1 ? 1).futureValue
+      (actor1 ? 2).futureValue
+      (actor1 ? Snapshot).futureValue
+    }
+    new EventSourcedCleanup(system).deleteAll("my-1", true).futureValue
+    withTestActors(replyToMessages = true) { (actor1, _, _) =>
+      (actor1 ? "state").futureValue.asInstanceOf[Int] shouldBe 0
+    }
+  }
+
+}
+
+class H2EventSourcedCleanupTest extends EventSourcedCleanupTest("h2-application.conf") with H2Cleaner

--- a/core/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
+++ b/core/src/test/scala/akka/persistence/jdbc/query/EventAdapterTest.scala
@@ -27,6 +27,8 @@ object EventAdapterTest {
 
   case class EventRestored(value: String)
 
+  case object Snapshot
+
   class TestReadEventAdapter extends ReadEventAdapter {
     override def fromJournal(event: Any, manifest: String): EventSeq =
       event match {

--- a/integration/src/test/scala/akka/persistence/jdbc/integration/EventSourcedCleanupTest.scala
+++ b/integration/src/test/scala/akka/persistence/jdbc/integration/EventSourcedCleanupTest.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2014 - 2019 Dennis Vriend <https://github.com/dnvriend>
+ * Copyright (C) 2019 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.jdbc.integration
+
+import akka.persistence.jdbc.cleanup.scaladsl.EventSourcedCleanupTest
+import akka.persistence.jdbc.query.{ MysqlCleaner, OracleCleaner, PostgresCleaner, SqlServerCleaner }
+
+// Note: these tests use the shared-db configs, the test for all (so not only current) events use the regular db config
+
+class PostgresEventSourcedCleanupTest
+    extends EventSourcedCleanupTest("postgres-shared-db-application.conf")
+    with PostgresCleaner
+
+class MySQLEventSourcedCleanupTest extends EventSourcedCleanupTest("mysql-shared-db-application.conf") with MysqlCleaner
+
+class OracleEventSourcedCleanupTest
+    extends EventSourcedCleanupTest("oracle-shared-db-application.conf")
+    with OracleCleaner
+
+class SqlServerEventSourcedCleanupTest
+    extends EventSourcedCleanupTest("sqlserver-shared-db-application.conf")
+    with SqlServerCleaner


### PR DESCRIPTION
This adds a cleanup tool, similar to akka-persistence-r2dbc.

I've kept the API really limited, only including the methods that I need for my use case.